### PR TITLE
Fix dot handling in dist-info directory name

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,13 @@
  importlib_metadata NEWS
 =========================
 
+v2.1.0
+======
+
+* #253: When querying for package metadata, the lookup
+  now honors
+  `package normalization rules <https://packaging.python.org/specifications/recording-installed-packages/>`_.
+
 v2.0.0
 ======
 

--- a/importlib_metadata/__init__.py
+++ b/importlib_metadata/__init__.py
@@ -473,7 +473,7 @@ class FastPath:
         for child in self.children():
             n_low = child.lower()
             if (n_low in name.exact_matches
-                    or n_low.replace('.', '_').startswith(name.prefix)
+                    or n_low.startswith(name.prefix)
                     and n_low.endswith(name.suffixes)
                     # legacy case:
                     or self.is_egg(name) and n_low == 'egg-info'):
@@ -494,11 +494,18 @@ class Prepared:
         self.name = name
         if name is None:
             return
-        self.normalized = name.lower().replace('-', '_')
+        self.normalized = self.normalize(name)
         self.prefix = self.normalized + '-'
         self.exact_matches = [
             self.normalized + suffix for suffix in self.suffixes]
         self.versionless_egg_name = self.normalized + '.egg'
+
+    @staticmethod
+    def normalize(name):
+        """
+        PEP 503 normalization plus dashes as underscores.
+        """
+        return re.sub(r"[-_.]+", "-", name).lower().replace('-', '_')
 
 
 @install

--- a/importlib_metadata/__init__.py
+++ b/importlib_metadata/__init__.py
@@ -473,7 +473,7 @@ class FastPath:
         for child in self.children():
             n_low = child.lower()
             if (n_low in name.exact_matches
-                    or n_low.startswith(name.prefix)
+                    or n_low.replace('.', '_').startswith(name.prefix)
                     and n_low.endswith(name.suffixes)
                     # legacy case:
                     or self.is_egg(name) and n_low == 'egg-info'):

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,6 +41,7 @@ testing =
     importlib_resources>=1.3; python_version < "3.9"
     packaging
     pep517
+    unittest2; python_version < "3"
 docs =
     sphinx
     rst.linker

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -106,7 +106,7 @@ class DistInfoPkg(OnSysPath, SiteDir):
 
 class DistInfoPkgWithDot(OnSysPath, SiteDir):
     files = {
-        "pkg.dot-1.0.0.dist-info": {
+        "pkg_dot-1.0.0.dist-info": {
             "METADATA": """
                 Name: pkg.dot
                 Version: 1.0.0

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -104,6 +104,21 @@ class DistInfoPkg(OnSysPath, SiteDir):
         build_files(DistInfoPkg.files, self.site_dir)
 
 
+class DistInfoPkgWithDot(OnSysPath, SiteDir):
+    files = {
+        "pkg.dot-1.0.0.dist-info": {
+            "METADATA": """
+                Name: pkg.dot
+                Version: 1.0.0
+                """,
+            },
+        }
+
+    def setUp(self):
+        super(DistInfoPkgWithDot, self).setUp()
+        build_files(DistInfoPkgWithDot.files, self.site_dir)
+
+
 class DistInfoPkgOffPath(SiteDir):
     def setUp(self):
         super(DistInfoPkgOffPath, self).setUp()

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -119,6 +119,21 @@ class DistInfoPkgWithDot(OnSysPath, SiteDir):
         build_files(DistInfoPkgWithDot.files, self.site_dir)
 
 
+class DistInfoPkgWithDotLegacy(OnSysPath, SiteDir):
+    files = {
+        "pkg.dot-1.0.0.dist-info": {
+            "METADATA": """
+                Name: pkg.dot
+                Version: 1.0.0
+                """,
+            },
+        }
+
+    def setUp(self):
+        super(DistInfoPkgWithDotLegacy, self).setUp()
+        build_files(DistInfoPkgWithDotLegacy.files, self.site_dir)
+
+
 class DistInfoPkgOffPath(SiteDir):
     def setUp(self):
         super(DistInfoPkgOffPath, self).setUp()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,6 +1,10 @@
 import re
 import textwrap
-import unittest
+
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
 
 from . import fixtures
 from importlib_metadata import (

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -42,8 +42,11 @@ class APITests(
         with self.assertRaises(PackageNotFoundError):
             distribution('does-not-exist')
 
-    def test_for_name_containing_dot(self):
-        assert distribution('pkg-dot').metadata['Name'] == 'pkg.dot'
+    def test_name_normalization(self):
+        names = 'pkg.dot', 'pkg_dot', 'pkg-dot', 'pkg..dot', 'Pkg.Dot'
+        for name in names:
+            with self.subTest(name):
+                assert distribution(name).metadata['Name'] == 'pkg.dot'
 
     def test_for_top_level(self):
         self.assertEqual(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -163,6 +163,14 @@ class APITests(
         assert deps == expected
 
 
+class LegacyDots(fixtures.DistInfoPkgWithDotLegacy, unittest.TestCase):
+    def test_name_normalization(self):
+        names = 'pkg.dot', 'pkg_dot', 'pkg-dot', 'pkg..dot', 'Pkg.Dot'
+        for name in names:
+            with self.subTest(name):
+                assert distribution(name).metadata['Name'] == 'pkg.dot'
+
+
 class OffSysPathTests(fixtures.DistInfoPkgOffPath, unittest.TestCase):
     def test_find_distributions_specified_path(self):
         dists = Distribution.discover(path=[str(self.site_dir)])

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -22,6 +22,7 @@ except ImportError:
 class APITests(
         fixtures.EggInfoPkg,
         fixtures.DistInfoPkg,
+        fixtures.DistInfoPkgWithDot,
         fixtures.EggInfoFile,
         unittest.TestCase):
 
@@ -40,6 +41,9 @@ class APITests(
     def test_for_name_does_not_exist(self):
         with self.assertRaises(PackageNotFoundError):
             distribution('does-not-exist')
+
+    def test_for_name_containing_dot(self):
+        assert distribution('pkg-dot').metadata['Name'] == 'pkg.dot'
 
     def test_for_top_level(self):
         self.assertEqual(


### PR DESCRIPTION
When searching for a matching dist-info directory, try to escape dots in the name segment. This makes functions like `distribution()` able to accept PEP 503 normalized names to locate a distribution’s dist-info directory
if the distribution’s name contains dots.

Related discussions:

* pipxproject/pipx#528
* pypa/packaging.python.org#781
* https://discuss.python.org/t/clarify-naming-of-dist-info-directories/5565?u=uranusjr