### PR TITLE
Versionless egg info pre normalized fallback

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,13 @@
  importlib_metadata NEWS
 =========================
 
+v2.1.1
+======
+
+* #261: Restored compatibility for package discovery for
+  metadata without version in the name and for legacy
+  eggs.
+
 v2.1.0
 ======
 

--- a/importlib_metadata/__init__.py
+++ b/importlib_metadata/__init__.py
@@ -474,7 +474,7 @@ class Prepared:
     """
     A prepared search for metadata on a possibly-named package.
     """
-    normalized = ''
+    normalized = None
     prefix = ''
     suffixes = '.dist-info', '.egg-info'
     exact_matches = [''][:0]
@@ -503,8 +503,10 @@ class Prepared:
         name, sep, rest = pre.partition('-')
         return (
             low in self.exact_matches
-            or name.replace('.', '_').startswith(self.normalized)
-            and ext in self.suffixes
+            or ext in self.suffixes and (
+                not self.normalized or
+                name.replace('.', '_') == self.normalized
+                )
             # legacy case:
             or self.is_egg(base) and low == 'egg-info'
             )

--- a/importlib_metadata/__init__.py
+++ b/importlib_metadata/__init__.py
@@ -497,14 +497,16 @@ class Prepared:
         """
         return re.sub(r"[-_.]+", "-", name).lower().replace('-', '_')
 
-    def matches(self, name, base):
-        n_low = name.lower()
+    def matches(self, cand, base):
+        low = cand.lower()
+        pre, ext = os.path.splitext(low)
+        name, sep, rest = pre.partition('-')
         return (
-            n_low in self.exact_matches
-            or n_low.replace('.', '_').startswith(self.prefix)
-            and n_low.endswith(self.suffixes)
+            low in self.exact_matches
+            or name.replace('.', '_').startswith(self.normalized)
+            and ext in self.suffixes
             # legacy case:
-            or self.is_egg(base) and n_low == 'egg-info'
+            or self.is_egg(base) and low == 'egg-info'
             )
 
     def is_egg(self, base):

--- a/importlib_metadata/__init__.py
+++ b/importlib_metadata/__init__.py
@@ -462,18 +462,11 @@ class FastPath:
             for child in names
             )
 
-    def is_egg(self, search):
-        base = self.base
-        return (
-            base == search.versionless_egg_name
-            or base.startswith(search.prefix)
-            and base.endswith('.egg'))
-
     def search(self, name):
         return (
             self.joinpath(child)
             for child in self.children()
-            if name.matches(child, self)
+            if name.matches(child, self.base)
             )
 
 
@@ -504,15 +497,21 @@ class Prepared:
         """
         return re.sub(r"[-_.]+", "-", name).lower().replace('-', '_')
 
-    def matches(self, name, path):
+    def matches(self, name, base):
         n_low = name.lower()
         return (
             n_low in self.exact_matches
             or n_low.replace('.', '_').startswith(self.prefix)
             and n_low.endswith(self.suffixes)
             # legacy case:
-            or path.is_egg(self) and n_low == 'egg-info'
+            or self.is_egg(base) and n_low == 'egg-info'
             )
+
+    def is_egg(self, base):
+        return (
+            base == self.versionless_egg_name
+            or base.startswith(self.prefix)
+            and base.endswith('.egg'))
 
 
 @install

--- a/importlib_metadata/__init__.py
+++ b/importlib_metadata/__init__.py
@@ -470,14 +470,11 @@ class FastPath:
             and base.endswith('.egg'))
 
     def search(self, name):
-        for child in self.children():
-            n_low = child.lower()
-            if (n_low in name.exact_matches
-                    or n_low.replace('.', '_').startswith(name.prefix)
-                    and n_low.endswith(name.suffixes)
-                    # legacy case:
-                    or self.is_egg(name) and n_low == 'egg-info'):
-                yield self.joinpath(child)
+        return (
+            self.joinpath(child)
+            for child in self.children()
+            if name.matches(child, self)
+            )
 
 
 class Prepared:
@@ -506,6 +503,16 @@ class Prepared:
         PEP 503 normalization plus dashes as underscores.
         """
         return re.sub(r"[-_.]+", "-", name).lower().replace('-', '_')
+
+    def matches(self, name, path):
+        n_low = name.lower()
+        return (
+            n_low in self.exact_matches
+            or n_low.replace('.', '_').startswith(self.prefix)
+            and n_low.endswith(self.suffixes)
+            # legacy case:
+            or path.is_egg(self) and n_low == 'egg-info'
+            )
 
 
 @install

--- a/importlib_metadata/__init__.py
+++ b/importlib_metadata/__init__.py
@@ -475,20 +475,16 @@ class Prepared:
     A prepared search for metadata on a possibly-named package.
     """
     normalized = None
-    prefix = ''
     suffixes = '.dist-info', '.egg-info'
     exact_matches = [''][:0]
-    versionless_egg_name = ''
 
     def __init__(self, name):
         self.name = name
         if name is None:
             return
         self.normalized = self.normalize(name)
-        self.prefix = self.normalized + '-'
         self.exact_matches = [
             self.normalized + suffix for suffix in self.suffixes]
-        self.versionless_egg_name = self.normalized + '.egg'
 
     @staticmethod
     def normalize(name):
@@ -496,6 +492,14 @@ class Prepared:
         PEP 503 normalization plus dashes as underscores.
         """
         return re.sub(r"[-_.]+", "-", name).lower().replace('-', '_')
+
+    @staticmethod
+    def legacy_normalize(name):
+        """
+        Normalize the package name as found in the convention in
+        older packaging tools versions and specs.
+        """
+        return name.lower().replace('-', '_')
 
     def matches(self, cand, base):
         low = cand.lower()
@@ -512,9 +516,12 @@ class Prepared:
             )
 
     def is_egg(self, base):
+        normalized = self.legacy_normalize(self.name or '')
+        prefix = normalized + '-' if normalized else ''
+        versionless_egg_name = normalized + '.egg' if self.name else ''
         return (
-            base == self.versionless_egg_name
-            or base.startswith(self.prefix)
+            base == versionless_egg_name
+            or base.startswith(prefix)
             and base.endswith('.egg'))
 
 

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -127,6 +127,12 @@ class DistInfoPkgWithDotLegacy(OnSysPath, SiteDir):
                 Version: 1.0.0
                 """,
             },
+        "pkg.lot.egg-info": {
+            "METADATA": """
+                Name: pkg.lot
+                Version: 1.0.0
+                """,
+            },
         }
 
     def setUp(self):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -174,6 +174,12 @@ class LegacyDots(fixtures.DistInfoPkgWithDotLegacy, unittest.TestCase):
             with self.subTest(name):
                 assert distribution(name).metadata['Name'] == 'pkg.dot'
 
+    def test_name_normalization_versionless_egg_info(self):
+        names = 'pkg.lot', 'pkg_lot', 'pkg-lot', 'pkg..lot', 'Pkg.Lot'
+        for name in names:
+            with self.subTest(name):
+                assert distribution(name).metadata['Name'] == 'pkg.lot'
+
 
 class OffSysPathTests(fixtures.DistInfoPkgOffPath, unittest.TestCase):
     def test_find_distributions_specified_path(self):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -52,6 +52,13 @@ class APITests(
             with self.subTest(name):
                 assert distribution(name).metadata['Name'] == 'pkg.dot'
 
+    def test_prefix_not_matched(self):
+        prefixes = 'p', 'pkg', 'pkg.'
+        for prefix in prefixes:
+            with self.subTest(prefix):
+                with self.assertRaises(PackageNotFoundError):
+                    distribution(prefix)
+
     def test_for_top_level(self):
         self.assertEqual(
             distribution('egginfo-pkg').read_text('top_level.txt').strip(),


### PR DESCRIPTION
Fixes #261.

This change restores the expectation that non-versioned names are supported in the legacy naming format. It also restores the legacy normalization for legacy eggs.

So much opportunity for error.