### PR TITLE
Further optimize distribution() searching.

### DIFF
--- a/importlib_metadata/__init__.py
+++ b/importlib_metadata/__init__.py
@@ -493,7 +493,7 @@ class Prepared:
     """
 
     normalized = None
-    suffixes = '.dist-info', '.egg-info'
+    suffixes = 'dist-info', 'egg-info'
     exact_matches = [''][:0]
 
     def __init__(self, name):
@@ -501,7 +501,9 @@ class Prepared:
         if name is None:
             return
         self.normalized = self.normalize(name)
-        self.exact_matches = [self.normalized + suffix for suffix in self.suffixes]
+        self.exact_matches = [
+            self.normalized + '.' + suffix for suffix in self.suffixes
+        ]
 
     @staticmethod
     def normalize(name):
@@ -520,8 +522,10 @@ class Prepared:
 
     def matches(self, cand, base):
         low = cand.lower()
-        pre, ext = os.path.splitext(low)
-        name, sep, rest = pre.partition('-')
+        # rpartition is like os.path.splitext, but much faster.  They'd only
+        # differ if pre is empty, but in that case we don't have a match anyways.
+        pre, _, ext = low.rpartition('.')
+        name, _, rest = pre.partition('-')
         return (
             low in self.exact_matches
             or ext in self.suffixes

--- a/importlib_metadata/__init__.py
+++ b/importlib_metadata/__init__.py
@@ -495,6 +495,8 @@ class Prepared:
     normalized = None
     suffixes = 'dist-info', 'egg-info'
     exact_matches = [''][:0]
+    egg_prefix = ''
+    versionless_egg_name = ''
 
     def __init__(self, name):
         self.name = name
@@ -504,6 +506,9 @@ class Prepared:
         self.exact_matches = [
             self.normalized + '.' + suffix for suffix in self.suffixes
         ]
+        legacy_normalized = self.legacy_normalize(self.name)
+        self.egg_prefix = legacy_normalized + '-'
+        self.versionless_egg_name = legacy_normalized + '.egg'
 
     @staticmethod
     def normalize(name):
@@ -536,12 +541,9 @@ class Prepared:
         )
 
     def is_egg(self, base):
-        normalized = self.legacy_normalize(self.name or '')
-        prefix = normalized + '-' if normalized else ''
-        versionless_egg_name = normalized + '.egg' if self.name else ''
         return (
-            base == versionless_egg_name
-            or base.startswith(prefix)
+            base == self.versionless_egg_name
+            or base.startswith(self.egg_prefix)
             and base.endswith('.egg')
         )
 

--- a/importlib_metadata/__init__.py
+++ b/importlib_metadata/__init__.py
@@ -565,8 +565,9 @@ class MetadataPathFinder(NullFinder, DistributionFinder):
     @classmethod
     def _search_paths(cls, name, paths):
         """Find metadata directories in paths heuristically."""
+        prepared = Prepared(name)
         return itertools.chain.from_iterable(
-            path.search(Prepared(name)) for path in map(FastPath, paths)
+            path.search(prepared) for path in map(FastPath, paths)
         )
 
 


### PR DESCRIPTION
Locally, this speeds up `distribution("ipython")` on a large-ish
environment by nearly 2-fold.  (The GHA benchmark goes from ~1.6ms
to ~0.8ms.)

All the following changes matter for the performance gain:
- avoid needlessly reinstanciating Prepareds.
- switch from os.path.splitext (very slow) to str.rpartition
- avoid having to add back a dot to the ext part given by rpartition
- precompute egg_prefix and versionless_egg_name

(See https://gitlab.com/python-devs/importlib_metadata/-/issues/95 for
rationale why performance matters.)