### PR TITLE
Feature/entry points by group and name

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,16 @@
+v3.5.0
+======
+
+* ``entry_points()`` now returns an ``GroupedEntryPoints``
+  object, a tuple of all entry points but with a convenience
+  property ``groups`` and ``__getitem__`` accessor. Further,
+  accessing a group returns an ``EntryPoints`` object,
+  another tuple of entry points in the group, accessible by
+  name. Construction of entry points using
+  ``dict([EntryPoint, ...])`` is now deprecated and raises
+  an appropriate DeprecationWarning and will be removed in
+  a future version.
+
 v3.4.0
 ======
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,17 +1,33 @@
+v4.0.0
+======
+
+* #284: Introduces new ``EntryPoints`` object, a tuple of
+  ``EntryPoint`` objects but with convenience properties for
+  selecting and inspecting the results:
+
+  - ``.select()`` accepts ``group`` or ``name`` keyword
+    parameters and returns a new ``EntryPoints`` tuple
+    with only those that match the selection.
+  - ``.groups`` property presents all of the group names.
+  - ``.names`` property presents the names of the entry points.
+  - Item access (e.g. ``eps[name]``) retrieves a single
+    entry point by name.
+
+  ``entry_points()`` now returns an ``EntryPoints``
+  object, but provides for backward compatibility with
+  a ``__getitem__`` accessor by group and a ``get()``
+  method.
+
+  Construction of entry points using
+  ``dict([EntryPoint, ...])`` is now deprecated and raises
+  an appropriate DeprecationWarning and will be removed in
+  a future version.
+
 v3.5.0
 ======
 
 * #280: ``entry_points`` now only returns entry points for
   unique distributions (by name).
-* ``entry_points()`` now returns an ``GroupedEntryPoints``
-  object, a tuple of all entry points but with a convenience
-  property ``groups`` and ``__getitem__`` accessor. Further,
-  accessing a group returns an ``EntryPoints`` object,
-  another tuple of entry points in the group, accessible by
-  name. Construction of entry points using
-  ``dict([EntryPoint, ...])`` is now deprecated and raises
-  an appropriate DeprecationWarning and will be removed in
-  a future version.
 
 v3.4.0
 ======

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,4 +1,4 @@
-v4.0.0
+v3.6.0
 ======
 
 * #284: Introduces new ``EntryPoints`` object, a tuple of
@@ -13,10 +13,21 @@ v4.0.0
   - Item access (e.g. ``eps[name]``) retrieves a single
     entry point by name.
 
-  ``entry_points()`` now returns an ``EntryPoints``
-  object, but provides for backward compatibility with
-  a ``__getitem__`` accessor by group and a ``get()``
-  method.
+  ``entry_points`` now accepts "selection parameters",
+  same as ``EntryPoint.select()``.
+
+  ``entry_points()`` now provides a future-compatible
+  ``SelectableGroups`` object that supplies the above interface
+  but remains a dict for compatibility.
+
+  In the future, ``entry_points()`` will return an
+  ``EntryPoints`` object, but provide for backward
+  compatibility with a deprecated  ``__getitem__``
+  accessor by group and a ``get()`` method.
+
+  If passing selection parameters to ``entry_points``, the
+  future behavior is invoked and an ``EntryPoints`` is the
+  result.
 
   Construction of entry points using
   ``dict([EntryPoint, ...])`` is now deprecated and raises

--- a/docs/using.rst
+++ b/docs/using.rst
@@ -67,7 +67,7 @@ This package provides the following functionality via its public API.
 Entry points
 ------------
 
-The ``entry_points()`` function returns a dictionary of all entry points,
+The ``entry_points()`` function returns a sequence of all entry points,
 keyed by group.  Entry points are represented by ``EntryPoint`` instances;
 each ``EntryPoint`` has a ``.name``, ``.group``, and ``.value`` attributes and
 a ``.load()`` method to resolve the value.  There are also ``.module``,
@@ -75,10 +75,12 @@ a ``.load()`` method to resolve the value.  There are also ``.module``,
 ``.value`` attribute::
 
     >>> eps = entry_points()
-    >>> list(eps)
+    >>> sorted(eps.groups)
     ['console_scripts', 'distutils.commands', 'distutils.setup_keywords', 'egg_info.writers', 'setuptools.installation']
     >>> scripts = eps['console_scripts']
-    >>> wheel = [ep for ep in scripts if ep.name == 'wheel'][0]
+    >>> 'wheel' in scripts.names
+    True
+    >>> wheel = scripts['wheel']
     >>> wheel
     EntryPoint(name='wheel', value='wheel.cli:main', group='console_scripts')
     >>> wheel.module

--- a/docs/using.rst
+++ b/docs/using.rst
@@ -67,8 +67,8 @@ This package provides the following functionality via its public API.
 Entry points
 ------------
 
-The ``entry_points()`` function returns a sequence of all entry points,
-keyed by group.  Entry points are represented by ``EntryPoint`` instances;
+The ``entry_points()`` function returns a collection of entry points.
+Entry points are represented by ``EntryPoint`` instances;
 each ``EntryPoint`` has a ``.name``, ``.group``, and ``.value`` attributes and
 a ``.load()`` method to resolve the value.  There are also ``.module``,
 ``.attr``, and ``.extras`` attributes for getting the components of the

--- a/docs/using.rst
+++ b/docs/using.rst
@@ -77,7 +77,7 @@ a ``.load()`` method to resolve the value.  There are also ``.module``,
     >>> eps = entry_points()
     >>> sorted(eps.groups)
     ['console_scripts', 'distutils.commands', 'distutils.setup_keywords', 'egg_info.writers', 'setuptools.installation']
-    >>> scripts = eps['console_scripts']
+    >>> scripts = eps.select(group='console_scripts')
     >>> 'wheel' in scripts.names
     True
     >>> wheel = scripts['wheel']

--- a/importlib_metadata/__init__.py
+++ b/importlib_metadata/__init__.py
@@ -180,6 +180,11 @@ class EntryPoints(tuple):
 
     @property
     def groups(self):
+        """
+        For coverage while SelectableGroups is present.
+        >>> EntryPoints().groups
+        set()
+        """
         return set(ep.group for ep in self)
 
     @classmethod
@@ -202,11 +207,16 @@ class SelectableGroups(dict):
 
     @property
     def groups(self):
-        return self.keys()
+        return set(self.keys())
 
     @property
     def names(self):
-        return (ep.name for ep in self._all)
+        """
+        for coverage:
+        >>> SelectableGroups().names
+        set()
+        """
+        return set(ep.name for ep in self._all)
 
     @property
     def _all(self):
@@ -218,7 +228,7 @@ class SelectableGroups(dict):
         return EntryPoints(self._all).select(**params)
 
 
-class LegacyGroupedEntryPoints(EntryPoints):
+class LegacyGroupedEntryPoints(EntryPoints):  # pragma: nocover
     """
     Compatibility wrapper around EntryPoints to provide
     much of the 'dict' interface previously returned by

--- a/importlib_metadata/__init__.py
+++ b/importlib_metadata/__init__.py
@@ -183,6 +183,14 @@ class GroupedEntryPoints(tuple):
     def groups(self):
         return set(ep.group for ep in self)
 
+    def get(self, group, default=None):
+        """
+        For backward compatibility, supply .get
+        """
+        msg = "GroupedEntryPoints.get is deprecated. Just use __getitem__."
+        warnings.warn(msg, DeprecationWarning)
+        return self[group] or default
+
 
 class PackagePath(pathlib.PurePosixPath):
     """A reference to a path in a package"""

--- a/importlib_metadata/__init__.py
+++ b/importlib_metadata/__init__.py
@@ -7,6 +7,7 @@ import zipp
 import email
 import pathlib
 import operator
+import warnings
 import functools
 import itertools
 import posixpath
@@ -139,11 +140,12 @@ class EntryPoint(
     def __iter__(self):
         """
         Supply iter so one may construct dicts of EntryPoints by name.
-
-        >>> eps = [EntryPoint('a', 'b', 'c'), EntryPoint('d', 'e', 'f')]
-        >>> dict(eps)['a']
-        EntryPoint(name='a', value='b', group='c')
         """
+        msg = (
+            "Construction of dict of EntryPoints is deprecated in "
+            "favor of EntryPoints."
+        )
+        warnings.warn(msg, DeprecationWarning)
         return iter((self.name, self))
 
     def __reduce__(self):

--- a/importlib_metadata/__init__.py
+++ b/importlib_metadata/__init__.py
@@ -206,8 +206,12 @@ class SelectableGroups(dict):
         return cls((group, EntryPoints(eps)) for group, eps in grouped)
 
     @property
+    def _all(self):
+        return EntryPoints(itertools.chain.from_iterable(self.values()))
+
+    @property
     def groups(self):
-        return set(self.keys())
+        return self._all.groups
 
     @property
     def names(self):
@@ -216,16 +220,12 @@ class SelectableGroups(dict):
         >>> SelectableGroups().names
         set()
         """
-        return set(ep.name for ep in self._all)
-
-    @property
-    def _all(self):
-        return itertools.chain.from_iterable(self.values())
+        return self._all.names
 
     def select(self, **params):
         if not params:
             return self
-        return EntryPoints(self._all).select(**params)
+        return self._all.select(**params)
 
 
 class LegacyGroupedEntryPoints(EntryPoints):  # pragma: nocover

--- a/importlib_metadata/__init__.py
+++ b/importlib_metadata/__init__.py
@@ -166,6 +166,10 @@ class EntryPoints(tuple):
         except Exception:
             raise KeyError(name)
 
+    @property
+    def names(self):
+        return set(ep.name for ep in self)
+
 
 class GroupedEntryPoints(tuple):
     """
@@ -174,6 +178,10 @@ class GroupedEntryPoints(tuple):
 
     def __getitem__(self, group) -> EntryPoints:
         return EntryPoints(ep for ep in self if ep.group == group)
+
+    @property
+    def groups(self):
+        return set(ep.group for ep in self)
 
 
 class PackagePath(pathlib.PurePosixPath):

--- a/importlib_metadata/__init__.py
+++ b/importlib_metadata/__init__.py
@@ -5,6 +5,7 @@ import csv
 import sys
 import zipp
 import email
+import inspect
 import pathlib
 import operator
 import warnings
@@ -191,8 +192,9 @@ class GroupedEntryPoints(tuple):
         """
         For backward compatibility, supply .get
         """
+        is_flake8 = any('flake8' in str(frame) for frame in inspect.stack())
         msg = "GroupedEntryPoints.get is deprecated. Just use __getitem__."
-        warnings.warn(msg, DeprecationWarning)
+        is_flake8 or warnings.warn(msg, DeprecationWarning)
         return self[group] or default
 
 

--- a/importlib_metadata/__init__.py
+++ b/importlib_metadata/__init__.py
@@ -157,8 +157,10 @@ class EntryPoint(
 
 class EntryPoints(tuple):
     """
-    A collection of EntryPoint objects, retrievable by name.
+    An immutable collection of EntryPoint objects, retrievable by name.
     """
+
+    __slots__ = ()
 
     def __getitem__(self, name) -> EntryPoint:
         try:
@@ -173,8 +175,10 @@ class EntryPoints(tuple):
 
 class GroupedEntryPoints(tuple):
     """
-    A collection of EntryPoint objects, retrievable by group.
+    An immutable collection of EntryPoint objects, retrievable by group.
     """
+
+    __slots__ = ()
 
     def __getitem__(self, group) -> EntryPoints:
         return EntryPoints(ep for ep in self if ep.group == group)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -82,6 +82,16 @@ class APITests(
     def test_entry_points_missing_group(self):
         assert entry_points()['missing'] == ()
 
+    def test_entry_points_dict_construction(self):
+        """
+        Prior versions of entry_points() returned simple lists and
+        allowed casting those lists into maps by name using ``dict()``.
+        Capture this now deprecated use-case.
+        """
+        eps = dict(entry_points()['entries'])
+        assert 'main' in eps
+        assert eps['main'] == entry_points()['entries']['main']
+
     def test_metadata_for_this_package(self):
         md = metadata('egginfo-pkg')
         assert md['author'] == 'Steven Ma'

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,6 +1,7 @@
 import re
 import textwrap
 import unittest
+import warnings
 
 from . import fixtures
 from importlib_metadata import (
@@ -88,9 +89,16 @@ class APITests(
         allowed casting those lists into maps by name using ``dict()``.
         Capture this now deprecated use-case.
         """
-        eps = dict(entry_points()['entries'])
+        with warnings.catch_warnings(record=True) as caught:
+            eps = dict(entry_points()['entries'])
+
         assert 'main' in eps
         assert eps['main'] == entry_points()['entries']['main']
+
+        # check warning
+        expected = next(iter(caught))
+        assert expected.category is DeprecationWarning
+        assert "Construction of dict of EntryPoints is deprecated" in str(expected)
 
     def test_metadata_for_this_package(self):
         md = metadata('egginfo-pkg')

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -64,17 +64,23 @@ class APITests(
         self.assertEqual(top_level.read_text(), 'mod\n')
 
     def test_entry_points(self):
-        entries = dict(entry_points()['entries'])
-        ep = entries['main']
+        ep = entry_points()['entries']['main']
         self.assertEqual(ep.value, 'mod:main')
         self.assertEqual(ep.extras, [])
 
     def test_entry_points_distribution(self):
-        entries = dict(entry_points()['entries'])
+        entries = entry_points()['entries']
         for entry in ("main", "ns:sub"):
             ep = entries[entry]
             self.assertIn(ep.dist.name, ('distinfo-pkg', 'egginfo-pkg'))
             self.assertEqual(ep.dist.version, "1.0.0")
+
+    def test_entry_points_missing_name(self):
+        with self.assertRaises(KeyError):
+            entry_points()['entries']['missing']
+
+    def test_entry_points_missing_group(self):
+        assert entry_points()['missing'] == ()
 
     def test_metadata_for_this_package(self):
         md = metadata('egginfo-pkg')

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -65,7 +65,11 @@ class APITests(
         self.assertEqual(top_level.read_text(), 'mod\n')
 
     def test_entry_points(self):
-        ep = entry_points()['entries']['main']
+        eps = entry_points()
+        assert 'entries' in eps.groups
+        entries = eps['entries']
+        assert 'main' in entries.names
+        ep = entries['main']
         self.assertEqual(ep.value, 'mod:main')
         self.assertEqual(ep.extras, [])
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -104,6 +104,17 @@ class APITests(
         assert expected.category is DeprecationWarning
         assert "Construction of dict of EntryPoints is deprecated" in str(expected)
 
+    def test_entry_points_groups_get(self):
+        """
+        Prior versions of entry_points() returned a dict. Ensure
+        that callers using '.get()' are supported but warned to
+        migrate.
+        """
+        with warnings.catch_warnings(record=True):
+            entry_points().get('missing', 'default') == 'default'
+            entry_points().get('entries', 'default') == entry_points()['entries']
+            entry_points().get('missing', ()) == entry_points()['missing']
+
     def test_metadata_for_this_package(self):
         md = metadata('egginfo-pkg')
         assert md['author'] == 'Steven Ma'

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -3,6 +3,7 @@ import json
 import pickle
 import textwrap
 import unittest
+import warnings
 import importlib
 import importlib_metadata
 import pyfakefs.fake_filesystem_unittest as ffs
@@ -247,7 +248,8 @@ class TestEntryPoints(unittest.TestCase):
         json should not expect to be able to dump an EntryPoint
         """
         with self.assertRaises(Exception):
-            json.dumps(self.ep)
+            with warnings.catch_warnings(record=True):
+                json.dumps(self.ep)
 
     def test_module(self):
         assert self.ep.module == 'value'

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -58,11 +58,11 @@ class ImportTests(fixtures.DistInfoPkg, unittest.TestCase):
             importlib.import_module('does_not_exist')
 
     def test_resolve(self):
-        ep = entry_points()['entries']['main']
+        ep = entry_points(group='entries')['main']
         self.assertEqual(ep.load().__name__, "main")
 
     def test_entrypoint_with_colon_in_name(self):
-        ep = entry_points()['entries']['ns:sub']
+        ep = entry_points(group='entries')['ns:sub']
         self.assertEqual(ep.value, 'mod:main')
 
     def test_resolve_without_attr(self):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -57,13 +57,11 @@ class ImportTests(fixtures.DistInfoPkg, unittest.TestCase):
             importlib.import_module('does_not_exist')
 
     def test_resolve(self):
-        entries = dict(entry_points()['entries'])
-        ep = entries['main']
+        ep = entry_points()['entries']['main']
         self.assertEqual(ep.load().__name__, "main")
 
     def test_entrypoint_with_colon_in_name(self):
-        entries = dict(entry_points()['entries'])
-        ep = entries['ns:sub']
+        ep = entry_points()['entries']['ns:sub']
         self.assertEqual(ep.value, 'mod:main')
 
     def test_resolve_without_attr(self):

--- a/tests/test_zip.py
+++ b/tests/test_zip.py
@@ -45,7 +45,7 @@ class TestZip(unittest.TestCase):
             version('definitely-not-installed')
 
     def test_zip_entry_points(self):
-        scripts = dict(entry_points()['console_scripts'])
+        scripts = entry_points()['console_scripts']
         entry_point = scripts['example']
         self.assertEqual(entry_point.value, 'example:main')
         entry_point = scripts['Example']

--- a/tests/test_zip.py
+++ b/tests/test_zip.py
@@ -45,7 +45,7 @@ class TestZip(unittest.TestCase):
             version('definitely-not-installed')
 
     def test_zip_entry_points(self):
-        scripts = entry_points()['console_scripts']
+        scripts = entry_points(group='console_scripts')
         entry_point = scripts['example']
         self.assertEqual(entry_point.value, 'example:main')
         entry_point = scripts['Example']


### PR DESCRIPTION
In pypa/twine#728, I learned that the `dict` hack for resolving a group of entry points by name is unintuitive, violates static type checks, and still doesn't provide an elegant way to resolve a set of entry points by group and name.

This finding inspired me to create this patch to provide an even nicer experience. See the changes to the docs and tests for examples of the improved usage.

The change is backward compatible for usages under test, but deprecates the `__iter__` on EntryPoint and `dict`-based construction.