### PR TITLE
Use a hand-written parser for entry points.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,11 @@ v3.9.0
   Preferably, switch to the ``select`` interface introduced
   in 3.7.0.
 
+* #283: Entry point parsing no longer relies on ConfigParser
+  and instead uses a custom, one-pass parser to load the
+  config, resulting in a ~20% performance improvement when
+  loading entry points.
+
 v3.8.0
 ======
 

--- a/importlib_metadata/__init__.py
+++ b/importlib_metadata/__init__.py
@@ -172,18 +172,6 @@ class EntryPoint(
         match = self.pattern.match(self.value)
         return list(re.finditer(r'\w+', match.group('extras') or ''))
 
-    @classmethod
-    def _from_text(cls, text):
-        return itertools.starmap(cls, cls._parse_groups(text or ''))
-
-    @staticmethod
-    def _parse_groups(text):
-        return (
-            (name, value, section)
-            for section, values in Sectioned.get_sections(text)
-            for name, value in values
-        )
-
     def _for(self, dist):
         self.dist = dist
         return self
@@ -253,7 +241,19 @@ class EntryPoints(tuple):
 
     @classmethod
     def _from_text_for(cls, text, dist):
-        return cls(ep._for(dist) for ep in EntryPoint._from_text(text))
+        return cls(ep._for(dist) for ep in cls._from_text(text))
+
+    @classmethod
+    def _from_text(cls, text):
+        return itertools.starmap(EntryPoint, cls._parse_groups(text or ''))
+
+    @staticmethod
+    def _parse_groups(text):
+        return (
+            (name, value, section)
+            for section, values in Sectioned.get_sections(text)
+            for name, value in values
+        )
 
 
 def flake8_bypass(func):


### PR DESCRIPTION
This speeds up the `entry_points()` tox perf check by ~30%, while being
both shorter and easier to follow.

See https://github.com/python/importlib_metadata/issues/283 and discussions linked therein.