### PR TITLE
Deprecate dict interface of entry_points result.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,10 @@
+v3.8.0
+======
+
+* Use of Mapping (dict) interfaces on ``SelectableGroups``
+  is now flagged as deprecated. Instead, users are advised
+  to use the select interface for future compatibility.
+
 v3.7.0
 ======
 
@@ -24,12 +31,10 @@ v3.6.0
 
   ``entry_points()`` now provides a future-compatible
   ``SelectableGroups`` object that supplies the above interface
-  but remains a dict for compatibility.
+  (except item access) but remains a dict for compatibility.
 
   In the future, ``entry_points()`` will return an
-  ``EntryPoints`` object, but provide for backward
-  compatibility with a deprecated  ``__getitem__``
-  accessor by group and a ``get()`` method.
+  ``EntryPoints`` object for all entry points.
 
   If passing selection parameters to ``entry_points``, the
   future behavior is invoked and an ``EntryPoints`` is the

--- a/importlib_metadata/__init__.py
+++ b/importlib_metadata/__init__.py
@@ -252,7 +252,7 @@ class Deprecated:
         return super().values()
 
 
-class SelectableGroups(dict):
+class SelectableGroups(Deprecated, dict):
     """
     A backward- and forward-compatible result from
     entry_points that fully implements the dict interface.
@@ -270,7 +270,8 @@ class SelectableGroups(dict):
         """
         Reconstruct a list of all entrypoints from the groups.
         """
-        return EntryPoints(itertools.chain.from_iterable(self.values()))
+        groups = super(Deprecated, self).values()
+        return EntryPoints(itertools.chain.from_iterable(groups))
 
     @property
     def groups(self):


### PR DESCRIPTION
Since #278, the dict interface on the result from `entry_points()` is deprecated. This change formalizes that deprecation and makes it visible through deprecation warnings.