### PR TITLE
Add json property to metadata result

### DIFF
--- a/importlib_metadata/__init__.py
+++ b/importlib_metadata/__init__.py
@@ -491,7 +491,7 @@ class Distribution:
             # (which points to the egg-info file) attribute unchanged.
             or self.read_text('')
         )
-        return _adapters.JSONMeta(email.message_from_string(text))
+        return _adapters.Message(email.message_from_string(text))
 
     @property
     def name(self):

--- a/importlib_metadata/_adapters.py
+++ b/importlib_metadata/_adapters.py
@@ -1,0 +1,66 @@
+import string
+import textwrap
+import itertools
+
+from . import _meta
+
+
+class JSONMeta(_meta.PackageMetadata):
+    def __init__(self, orig: _meta.PackageMetadata):
+        self.orig = orig
+
+    def __getitem__(self, item):
+        return self.orig.__getitem__(item)
+
+    def __len__(self):
+        return self.orig.__len__()  # pragma: nocover
+
+    def __contains__(self, item):
+        return self.orig.__contains__(item)  # pragma: nocover
+
+    def __iter__(self):
+        return self.orig.__iter__()
+
+    def get_all(self, name):
+        return self.orig.get_all(name)
+
+    def get_payload(self):
+        return self.orig.get_payload()
+
+    @property
+    def json(self):
+        """
+        Convert PackageMetadata to a JSON-compatible format
+        per PEP 0566.
+        """
+        # TODO: Need to match case-insensitive
+        multiple_use = {
+            'Classifier',
+            'Obsoletes-Dist',
+            'Platform',
+            'Project-URL',
+            'Provides-Dist',
+            'Provides-Extra',
+            'Requires-Dist',
+            'Requires-External',
+            'Supported-Platform',
+        }
+
+        def redent(value):
+            "Correct for RFC822 indentation"
+            if not value or '\n' not in value:
+                return value
+            return textwrap.dedent(' ' * 8 + value)
+
+        def transform(key):
+            value = self.get_all(key) if key in multiple_use else redent(self[key])
+            if key == 'Keywords':
+                value = value.split(string.whitespace)
+            if not value and key == 'Description':
+                value = self.get_payload()
+            tk = key.lower().replace('-', '_')
+            return tk, value
+
+        desc = ['Description'] if self.get_payload() else []
+        keys = itertools.chain(self, desc)
+        return dict(map(transform, keys))

--- a/importlib_metadata/_adapters.py
+++ b/importlib_metadata/_adapters.py
@@ -1,31 +1,17 @@
 import string
 import textwrap
 import itertools
+import email.message
 
-from . import _meta
 
+class Message(email.message.Message):
+    def __new__(cls, orig: email.message.Message):
+        res = super().__new__(cls)
+        vars(res).update(vars(orig))
+        return res
 
-class JSONMeta(_meta.PackageMetadata):
-    def __init__(self, orig: _meta.PackageMetadata):
-        self.orig = orig
-
-    def __getitem__(self, item):
-        return self.orig.__getitem__(item)
-
-    def __len__(self):
-        return self.orig.__len__()  # pragma: nocover
-
-    def __contains__(self, item):
-        return self.orig.__contains__(item)  # pragma: nocover
-
-    def __iter__(self):
-        return self.orig.__iter__()
-
-    def get_all(self, name):
-        return self.orig.get_all(name)
-
-    def get_payload(self):
-        return self.orig.get_payload()
+    def __init__(self, *args, **kwargs):
+        pass
 
     @property
     def json(self):

--- a/importlib_metadata/_adapters.py
+++ b/importlib_metadata/_adapters.py
@@ -13,6 +13,10 @@ class Message(email.message.Message):
     def __init__(self, *args, **kwargs):
         pass
 
+    # suppress spurious error from mypy
+    def __iter__(self):
+        return super().__iter__()
+
     @property
     def json(self):
         """

--- a/importlib_metadata/_meta.py
+++ b/importlib_metadata/_meta.py
@@ -1,0 +1,24 @@
+from ._compat import Protocol
+from typing import Any, List, TypeVar, Union
+
+
+_T = TypeVar("_T")
+
+
+class PackageMetadata(Protocol):
+    def __len__(self) -> int:
+        ...  # pragma: no cover
+
+    def __contains__(self, item: str) -> bool:
+        ...  # pragma: no cover
+
+    def __getitem__(self, key: str) -> str:
+        ...  # pragma: no cover
+
+    def get_payload(self) -> str:
+        ...  # pragma: no cover
+
+    def get_all(self, name: str, failobj: _T = ...) -> Union[List[Any], _T]:
+        """
+        Return all values associated with a possibly multi-valued key.
+        """

--- a/importlib_metadata/_meta.py
+++ b/importlib_metadata/_meta.py
@@ -1,5 +1,5 @@
 from ._compat import Protocol
-from typing import Any, List, TypeVar, Union
+from typing import Any, Dict, Iterator, List, TypeVar, Union
 
 
 _T = TypeVar("_T")
@@ -15,10 +15,19 @@ class PackageMetadata(Protocol):
     def __getitem__(self, key: str) -> str:
         ...  # pragma: no cover
 
+    def __iter__(self) -> Iterator[str]:
+        ...  # pragma: no cover
+
     def get_payload(self) -> str:
         ...  # pragma: no cover
 
     def get_all(self, name: str, failobj: _T = ...) -> Union[List[Any], _T]:
         """
         Return all values associated with a possibly multi-valued key.
+        """
+
+    @property
+    def json(self) -> Dict[str, Union[str, List[str]]]:
+        """
+        A JSON-compatible form of the metadata.
         """

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -8,6 +8,7 @@ from . import fixtures
 from importlib_metadata import (
     Distribution,
     PackageNotFoundError,
+    as_json,
     distribution,
     entry_points,
     files,
@@ -245,6 +246,18 @@ class APITests(
         # tightly than some other part of the environment expression.
 
         assert deps == expected
+
+    def test_as_json(self):
+        md = as_json(metadata('distinfo-pkg'))
+        assert 'name' in md
+        desc = md['description']
+        assert desc.startswith('Once upon a time\nThere was')
+
+    def test_as_json_egg_info(self):
+        md = as_json(metadata('egginfo-pkg'))
+        assert 'name' in md
+        desc = md['description']
+        assert desc.startswith('Once upon a time\nThere was')
 
 
 class LegacyDots(fixtures.DistInfoPkgWithDotLegacy, unittest.TestCase):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -8,7 +8,6 @@ from . import fixtures
 from importlib_metadata import (
     Distribution,
     PackageNotFoundError,
-    as_json,
     distribution,
     entry_points,
     files,
@@ -248,13 +247,13 @@ class APITests(
         assert deps == expected
 
     def test_as_json(self):
-        md = as_json(metadata('distinfo-pkg'))
+        md = metadata('distinfo-pkg').json
         assert 'name' in md
         desc = md['description']
         assert desc.startswith('Once upon a time\nThere was')
 
     def test_as_json_egg_info(self):
-        md = as_json(metadata('egginfo-pkg'))
+        md = metadata('egginfo-pkg').json
         assert 'name' in md
         desc = md['description']
         assert desc.startswith('Once upon a time\nThere was')


### PR DESCRIPTION
Alternate to #301, this approach wraps the metadata result in an object with a json property. This approach has the advantage that it doesn't add anything to the namespace and gives consumers access to the json on their existing object.

It has the downside of adding new demands on the `PackageMetadata` protocol (namely that it must have a `.json` property).