### PR TITLE
Repair and clean metadata

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,24 @@
+v4.0.0
+=======
+
+* #304: ``PackageMetadata`` as returned by ``metadata()``
+  and ``Distribution.metadata()`` now provides normalized
+  metadata honoring PEP 566:
+
+  - If a long description is provided in the payload of the
+    RFC 822 value, it can be retrieved as the ``Description``
+    field.
+  - Any multi-line values in the metadata will be returned as
+    such.
+  - For any multi-line values, line continuation characters
+    are removed. This backward-incompatible change means
+    that any projects relying on the RFC 822 line continuation
+    characters being present must be tolerant to them having
+    been removed.
+  - Add a ``json`` property that provides the metadata
+    converted to a JSON-compatible form per PEP 566.
+
+
 v3.10.0
 =======
 

--- a/importlib_metadata/__init__.py
+++ b/importlib_metadata/__init__.py
@@ -491,7 +491,7 @@ class Distribution:
             # (which points to the egg-info file) attribute unchanged.
             or self.read_text('')
         )
-        return _adapters.JSONMeta(email.message_from_string(text))
+        return _adapters.Message(email.message_from_string(text))
 
     @property
     def name(self):

--- a/importlib_metadata/_adapters.py
+++ b/importlib_metadata/_adapters.py
@@ -1,0 +1,66 @@
+import string
+import textwrap
+import itertools
+
+from . import _meta
+
+
+class JSONMeta(_meta.PackageMetadata):
+    def __init__(self, orig: _meta.PackageMetadata):
+        self.orig = orig
+
+    def __getitem__(self, item):
+        return self.orig.__getitem__(item)
+
+    def __len__(self):
+        return self.orig.__len__()  # pragma: nocover
+
+    def __contains__(self, item):
+        return self.orig.__contains__(item)  # pragma: nocover
+
+    def __iter__(self):
+        return self.orig.__iter__()
+
+    def get_all(self, name):
+        return self.orig.get_all(name)
+
+    def get_payload(self):
+        return self.orig.get_payload()
+
+    @property
+    def json(self):
+        """
+        Convert PackageMetadata to a JSON-compatible format
+        per PEP 0566.
+        """
+        # TODO: Need to match case-insensitive
+        multiple_use = {
+            'Classifier',
+            'Obsoletes-Dist',
+            'Platform',
+            'Project-URL',
+            'Provides-Dist',
+            'Provides-Extra',
+            'Requires-Dist',
+            'Requires-External',
+            'Supported-Platform',
+        }
+
+        def redent(value):
+            "Correct for RFC822 indentation"
+            if not value or '\n' not in value:
+                return value
+            return textwrap.dedent(' ' * 8 + value)
+
+        def transform(key):
+            value = self.get_all(key) if key in multiple_use else redent(self[key])
+            if key == 'Keywords':
+                value = value.split(string.whitespace)
+            if not value and key == 'Description':
+                value = self.get_payload()
+            tk = key.lower().replace('-', '_')
+            return tk, value
+
+        desc = ['Description'] if self.get_payload() else []
+        keys = itertools.chain(self, desc)
+        return dict(map(transform, keys))

--- a/importlib_metadata/_adapters.py
+++ b/importlib_metadata/_adapters.py
@@ -2,10 +2,30 @@ import re
 import textwrap
 import email.message
 
-from ._functools import method_cache
+from ._text import FoldedCase
 
 
 class Message(email.message.Message):
+    multiple_use_keys = set(
+        map(
+            FoldedCase,
+            [
+                'Classifier',
+                'Obsoletes-Dist',
+                'Platform',
+                'Project-URL',
+                'Provides-Dist',
+                'Provides-Extra',
+                'Requires-Dist',
+                'Requires-External',
+                'Supported-Platform',
+            ],
+        )
+    )
+    """
+    Keys that may be indicated multiple times per PEP 566.
+    """
+
     def __new__(cls, orig: email.message.Message):
         res = super().__new__(cls)
         vars(res).update(vars(orig))
@@ -36,124 +56,12 @@ class Message(email.message.Message):
         Convert PackageMetadata to a JSON-compatible format
         per PEP 0566.
         """
-        multiple_use = set(
-            map(
-                FoldedCase,
-                [
-                    'Classifier',
-                    'Obsoletes-Dist',
-                    'Platform',
-                    'Project-URL',
-                    'Provides-Dist',
-                    'Provides-Extra',
-                    'Requires-Dist',
-                    'Requires-External',
-                    'Supported-Platform',
-                ],
-            )
-        )
 
         def transform(key):
-            value = self.get_all(key) if key in multiple_use else self[key]
+            value = self.get_all(key) if key in self.multiple_use_keys else self[key]
             if key == 'Keywords':
                 value = re.split(r'\s+', value)
             tk = key.lower().replace('-', '_')
             return tk, value
 
         return dict(map(transform, map(FoldedCase, self)))
-
-
-# from jaraco.text 3.5
-class FoldedCase(str):
-    """
-    A case insensitive string class; behaves just like str
-    except compares equal when the only variation is case.
-
-    >>> s = FoldedCase('hello world')
-
-    >>> s == 'Hello World'
-    True
-
-    >>> 'Hello World' == s
-    True
-
-    >>> s != 'Hello World'
-    False
-
-    >>> s.index('O')
-    4
-
-    >>> s.split('O')
-    ['hell', ' w', 'rld']
-
-    >>> sorted(map(FoldedCase, ['GAMMA', 'alpha', 'Beta']))
-    ['alpha', 'Beta', 'GAMMA']
-
-    Sequence membership is straightforward.
-
-    >>> "Hello World" in [s]
-    True
-    >>> s in ["Hello World"]
-    True
-
-    You may test for set inclusion, but candidate and elements
-    must both be folded.
-
-    >>> FoldedCase("Hello World") in {s}
-    True
-    >>> s in {FoldedCase("Hello World")}
-    True
-
-    String inclusion works as long as the FoldedCase object
-    is on the right.
-
-    >>> "hello" in FoldedCase("Hello World")
-    True
-
-    But not if the FoldedCase object is on the left:
-
-    >>> FoldedCase('hello') in 'Hello World'
-    False
-
-    In that case, use in_:
-
-    >>> FoldedCase('hello').in_('Hello World')
-    True
-
-    >>> FoldedCase('hello') > FoldedCase('Hello')
-    False
-    """
-
-    def __lt__(self, other):
-        return self.lower() < other.lower()
-
-    def __gt__(self, other):
-        return self.lower() > other.lower()
-
-    def __eq__(self, other):
-        return self.lower() == other.lower()
-
-    def __ne__(self, other):
-        return self.lower() != other.lower()
-
-    def __hash__(self):
-        return hash(self.lower())
-
-    def __contains__(self, other):
-        return super(FoldedCase, self).lower().__contains__(other.lower())
-
-    def in_(self, other):
-        "Does self appear in other?"
-        return self in FoldedCase(other)
-
-    # cache lower since it's likely to be called frequently.
-    @method_cache
-    def lower(self):
-        return super(FoldedCase, self).lower()
-
-    def index(self, sub):
-        return self.lower().index(sub.lower())
-
-    def split(self, splitter=' ', maxsplit=0):
-        pattern = re.compile(re.escape(splitter), re.I)
-        return pattern.split(self, maxsplit)

--- a/importlib_metadata/_adapters.py
+++ b/importlib_metadata/_adapters.py
@@ -2,6 +2,8 @@ import re
 import textwrap
 import email.message
 
+from ._functools import method_cache
+
 
 class Message(email.message.Message):
     def __new__(cls, orig: email.message.Message):
@@ -34,18 +36,22 @@ class Message(email.message.Message):
         Convert PackageMetadata to a JSON-compatible format
         per PEP 0566.
         """
-        # TODO: Need to match case-insensitive
-        multiple_use = {
-            'Classifier',
-            'Obsoletes-Dist',
-            'Platform',
-            'Project-URL',
-            'Provides-Dist',
-            'Provides-Extra',
-            'Requires-Dist',
-            'Requires-External',
-            'Supported-Platform',
-        }
+        multiple_use = set(
+            map(
+                FoldedCase,
+                [
+                    'Classifier',
+                    'Obsoletes-Dist',
+                    'Platform',
+                    'Project-URL',
+                    'Provides-Dist',
+                    'Provides-Extra',
+                    'Requires-Dist',
+                    'Requires-External',
+                    'Supported-Platform',
+                ],
+            )
+        )
 
         def transform(key):
             value = self.get_all(key) if key in multiple_use else self[key]
@@ -54,4 +60,100 @@ class Message(email.message.Message):
             tk = key.lower().replace('-', '_')
             return tk, value
 
-        return dict(map(transform, self))
+        return dict(map(transform, map(FoldedCase, self)))
+
+
+# from jaraco.text 3.5
+class FoldedCase(str):
+    """
+    A case insensitive string class; behaves just like str
+    except compares equal when the only variation is case.
+
+    >>> s = FoldedCase('hello world')
+
+    >>> s == 'Hello World'
+    True
+
+    >>> 'Hello World' == s
+    True
+
+    >>> s != 'Hello World'
+    False
+
+    >>> s.index('O')
+    4
+
+    >>> s.split('O')
+    ['hell', ' w', 'rld']
+
+    >>> sorted(map(FoldedCase, ['GAMMA', 'alpha', 'Beta']))
+    ['alpha', 'Beta', 'GAMMA']
+
+    Sequence membership is straightforward.
+
+    >>> "Hello World" in [s]
+    True
+    >>> s in ["Hello World"]
+    True
+
+    You may test for set inclusion, but candidate and elements
+    must both be folded.
+
+    >>> FoldedCase("Hello World") in {s}
+    True
+    >>> s in {FoldedCase("Hello World")}
+    True
+
+    String inclusion works as long as the FoldedCase object
+    is on the right.
+
+    >>> "hello" in FoldedCase("Hello World")
+    True
+
+    But not if the FoldedCase object is on the left:
+
+    >>> FoldedCase('hello') in 'Hello World'
+    False
+
+    In that case, use in_:
+
+    >>> FoldedCase('hello').in_('Hello World')
+    True
+
+    >>> FoldedCase('hello') > FoldedCase('Hello')
+    False
+    """
+
+    def __lt__(self, other):
+        return self.lower() < other.lower()
+
+    def __gt__(self, other):
+        return self.lower() > other.lower()
+
+    def __eq__(self, other):
+        return self.lower() == other.lower()
+
+    def __ne__(self, other):
+        return self.lower() != other.lower()
+
+    def __hash__(self):
+        return hash(self.lower())
+
+    def __contains__(self, other):
+        return super(FoldedCase, self).lower().__contains__(other.lower())
+
+    def in_(self, other):
+        "Does self appear in other?"
+        return self in FoldedCase(other)
+
+    # cache lower since it's likely to be called frequently.
+    @method_cache
+    def lower(self):
+        return super(FoldedCase, self).lower()
+
+    def index(self, sub):
+        return self.lower().index(sub.lower())
+
+    def split(self, splitter=' ', maxsplit=0):
+        pattern = re.compile(re.escape(splitter), re.I)
+        return pattern.split(self, maxsplit)

--- a/importlib_metadata/_adapters.py
+++ b/importlib_metadata/_adapters.py
@@ -1,4 +1,4 @@
-import string
+import re
 import textwrap
 import email.message
 
@@ -50,7 +50,7 @@ class Message(email.message.Message):
         def transform(key):
             value = self.get_all(key) if key in multiple_use else self[key]
             if key == 'Keywords':
-                value = value.split(string.whitespace)
+                value = re.split(r'\s+', value)
             tk = key.lower().replace('-', '_')
             return tk, value
 

--- a/importlib_metadata/_adapters.py
+++ b/importlib_metadata/_adapters.py
@@ -1,31 +1,17 @@
 import string
 import textwrap
 import itertools
+import email.message
 
-from . import _meta
 
+class Message(email.message.Message):
+    def __new__(cls, orig: email.message.Message):
+        res = super().__new__(cls)
+        vars(res).update(vars(orig))
+        return res
 
-class JSONMeta(_meta.PackageMetadata):
-    def __init__(self, orig: _meta.PackageMetadata):
-        self.orig = orig
-
-    def __getitem__(self, item):
-        return self.orig.__getitem__(item)
-
-    def __len__(self):
-        return self.orig.__len__()  # pragma: nocover
-
-    def __contains__(self, item):
-        return self.orig.__contains__(item)  # pragma: nocover
-
-    def __iter__(self):
-        return self.orig.__iter__()
-
-    def get_all(self, name):
-        return self.orig.get_all(name)
-
-    def get_payload(self):
-        return self.orig.get_payload()
+    def __init__(self, *args, **kwargs):
+        pass
 
     @property
     def json(self):

--- a/importlib_metadata/_adapters.py
+++ b/importlib_metadata/_adapters.py
@@ -13,6 +13,10 @@ class Message(email.message.Message):
     def __init__(self, *args, **kwargs):
         pass
 
+    # suppress spurious error from mypy
+    def __iter__(self):
+        return super().__iter__()
+
     @property
     def json(self):
         """

--- a/importlib_metadata/_meta.py
+++ b/importlib_metadata/_meta.py
@@ -1,0 +1,24 @@
+from ._compat import Protocol
+from typing import Any, List, TypeVar, Union
+
+
+_T = TypeVar("_T")
+
+
+class PackageMetadata(Protocol):
+    def __len__(self) -> int:
+        ...  # pragma: no cover
+
+    def __contains__(self, item: str) -> bool:
+        ...  # pragma: no cover
+
+    def __getitem__(self, key: str) -> str:
+        ...  # pragma: no cover
+
+    def get_payload(self) -> str:
+        ...  # pragma: no cover
+
+    def get_all(self, name: str, failobj: _T = ...) -> Union[List[Any], _T]:
+        """
+        Return all values associated with a possibly multi-valued key.
+        """

--- a/importlib_metadata/_meta.py
+++ b/importlib_metadata/_meta.py
@@ -1,5 +1,5 @@
 from ._compat import Protocol
-from typing import Any, List, TypeVar, Union
+from typing import Any, Dict, Iterator, List, TypeVar, Union
 
 
 _T = TypeVar("_T")
@@ -15,10 +15,19 @@ class PackageMetadata(Protocol):
     def __getitem__(self, key: str) -> str:
         ...  # pragma: no cover
 
+    def __iter__(self) -> Iterator[str]:
+        ...  # pragma: no cover
+
     def get_payload(self) -> str:
         ...  # pragma: no cover
 
     def get_all(self, name: str, failobj: _T = ...) -> Union[List[Any], _T]:
         """
         Return all values associated with a possibly multi-valued key.
+        """
+
+    @property
+    def json(self) -> Dict[str, Union[str, List[str]]]:
+        """
+        A JSON-compatible form of the metadata.
         """

--- a/importlib_metadata/_meta.py
+++ b/importlib_metadata/_meta.py
@@ -18,9 +18,6 @@ class PackageMetadata(Protocol):
     def __iter__(self) -> Iterator[str]:
         ...  # pragma: no cover
 
-    def get_payload(self) -> str:
-        ...  # pragma: no cover
-
     def get_all(self, name: str, failobj: _T = ...) -> Union[List[Any], _T]:
         """
         Return all values associated with a possibly multi-valued key.

--- a/importlib_metadata/_text.py
+++ b/importlib_metadata/_text.py
@@ -1,0 +1,99 @@
+import re
+
+from ._functools import method_cache
+
+
+# from jaraco.text 3.5
+class FoldedCase(str):
+    """
+    A case insensitive string class; behaves just like str
+    except compares equal when the only variation is case.
+
+    >>> s = FoldedCase('hello world')
+
+    >>> s == 'Hello World'
+    True
+
+    >>> 'Hello World' == s
+    True
+
+    >>> s != 'Hello World'
+    False
+
+    >>> s.index('O')
+    4
+
+    >>> s.split('O')
+    ['hell', ' w', 'rld']
+
+    >>> sorted(map(FoldedCase, ['GAMMA', 'alpha', 'Beta']))
+    ['alpha', 'Beta', 'GAMMA']
+
+    Sequence membership is straightforward.
+
+    >>> "Hello World" in [s]
+    True
+    >>> s in ["Hello World"]
+    True
+
+    You may test for set inclusion, but candidate and elements
+    must both be folded.
+
+    >>> FoldedCase("Hello World") in {s}
+    True
+    >>> s in {FoldedCase("Hello World")}
+    True
+
+    String inclusion works as long as the FoldedCase object
+    is on the right.
+
+    >>> "hello" in FoldedCase("Hello World")
+    True
+
+    But not if the FoldedCase object is on the left:
+
+    >>> FoldedCase('hello') in 'Hello World'
+    False
+
+    In that case, use in_:
+
+    >>> FoldedCase('hello').in_('Hello World')
+    True
+
+    >>> FoldedCase('hello') > FoldedCase('Hello')
+    False
+    """
+
+    def __lt__(self, other):
+        return self.lower() < other.lower()
+
+    def __gt__(self, other):
+        return self.lower() > other.lower()
+
+    def __eq__(self, other):
+        return self.lower() == other.lower()
+
+    def __ne__(self, other):
+        return self.lower() != other.lower()
+
+    def __hash__(self):
+        return hash(self.lower())
+
+    def __contains__(self, other):
+        return super(FoldedCase, self).lower().__contains__(other.lower())
+
+    def in_(self, other):
+        "Does self appear in other?"
+        return self in FoldedCase(other)
+
+    # cache lower since it's likely to be called frequently.
+    @method_cache
+    def lower(self):
+        return super(FoldedCase, self).lower()
+
+    def index(self, sub):
+        return self.lower().index(sub.lower())
+
+    def split(self, splitter=' ', maxsplit=0):
+        pattern = re.compile(re.escape(splitter), re.I)
+        return pattern.split(self, maxsplit)

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import copy
 import shutil
 import pathlib
 import tempfile
@@ -107,6 +108,16 @@ class DistInfoPkg(OnSysPath, SiteDir):
     def setUp(self):
         super(DistInfoPkg, self).setUp()
         build_files(DistInfoPkg.files, self.site_dir)
+
+    def make_uppercase(self):
+        """
+        Rewrite metadata with everything uppercase.
+        """
+        shutil.rmtree(self.site_dir / "distinfo_pkg-1.0.0.dist-info")
+        files = copy.deepcopy(DistInfoPkg.files)
+        info = files["distinfo_pkg-1.0.0.dist-info"]
+        info["METADATA"] = info["METADATA"].upper()
+        build_files(files, self.site_dir)
 
 
 class DistInfoPkgWithDot(OnSysPath, SiteDir):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -8,6 +8,7 @@ from . import fixtures
 from importlib_metadata import (
     Distribution,
     PackageNotFoundError,
+    as_json,
     distribution,
     entry_points,
     files,
@@ -245,6 +246,18 @@ class APITests(
         # tightly than some other part of the environment expression.
 
         assert deps == expected
+
+    def test_as_json(self):
+        md = as_json(metadata('distinfo-pkg'))
+        assert 'name' in md
+        desc = md['description']
+        assert desc.startswith('Once upon a time\nThere was')
+
+    def test_as_json_egg_info(self):
+        md = as_json(metadata('egginfo-pkg'))
+        assert 'name' in md
+        desc = md['description']
+        assert desc.startswith('Once upon a time\nThere was')
 
 
 class LegacyDots(fixtures.DistInfoPkgWithDotLegacy, unittest.TestCase):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -8,7 +8,6 @@ from . import fixtures
 from importlib_metadata import (
     Distribution,
     PackageNotFoundError,
-    as_json,
     distribution,
     entry_points,
     files,
@@ -248,13 +247,13 @@ class APITests(
         assert deps == expected
 
     def test_as_json(self):
-        md = as_json(metadata('distinfo-pkg'))
+        md = metadata('distinfo-pkg').json
         assert 'name' in md
         desc = md['description']
         assert desc.startswith('Once upon a time\nThere was')
 
     def test_as_json_egg_info(self):
-        md = as_json(metadata('egginfo-pkg'))
+        md = metadata('egginfo-pkg').json
         assert 'name' in md
         desc = md['description']
         assert desc.startswith('Once upon a time\nThere was')

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -249,12 +249,14 @@ class APITests(
     def test_as_json(self):
         md = metadata('distinfo-pkg').json
         assert 'name' in md
+        assert md['keywords'] == ['sample', 'package']
         desc = md['description']
         assert desc.startswith('Once upon a time\nThere was')
 
     def test_as_json_egg_info(self):
         md = metadata('egginfo-pkg').json
         assert 'name' in md
+        assert md['keywords'] == ['sample', 'package']
         desc = md['description']
         assert desc.startswith('Once upon a time\nThere was')
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -262,6 +262,13 @@ class APITests(
         assert desc.startswith('Once upon a time\nThere was')
         assert len(md['classifier']) == 2
 
+    def test_as_json_odd_case(self):
+        self.make_uppercase()
+        md = metadata('distinfo-pkg').json
+        assert 'name' in md
+        assert len(md['requires_dist']) == 2
+        assert md['keywords'] == ['SAMPLE', 'PACKAGE']
+
 
 class LegacyDots(fixtures.DistInfoPkgWithDotLegacy, unittest.TestCase):
     def test_name_normalization(self):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -252,6 +252,7 @@ class APITests(
         assert md['keywords'] == ['sample', 'package']
         desc = md['description']
         assert desc.startswith('Once upon a time\nThere was')
+        assert len(md['requires_dist']) == 2
 
     def test_as_json_egg_info(self):
         md = metadata('egginfo-pkg').json
@@ -259,6 +260,7 @@ class APITests(
         assert md['keywords'] == ['sample', 'package']
         desc = md['description']
         assert desc.startswith('Once upon a time\nThere was')
+        assert len(md['classifier']) == 2
 
 
 class LegacyDots(fixtures.DistInfoPkgWithDotLegacy, unittest.TestCase):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -130,7 +130,7 @@ class NonASCIITests(fixtures.OnSysPath, fixtures.SiteDir, unittest.TestCase):
         metadata_dir.mkdir()
         metadata = metadata_dir / 'METADATA'
         with metadata.open('w', encoding='utf-8') as fp:
-            fp.write('Description: pôrˈtend\n')
+            fp.write('Description: pôrˈtend')
         return 'portend'
 
     @staticmethod
@@ -150,7 +150,7 @@ class NonASCIITests(fixtures.OnSysPath, fixtures.SiteDir, unittest.TestCase):
 
                 pôrˈtend
                 """
-                ).lstrip()
+                ).strip()
             )
         return 'portend'
 
@@ -162,7 +162,7 @@ class NonASCIITests(fixtures.OnSysPath, fixtures.SiteDir, unittest.TestCase):
     def test_metadata_loads_egg_info(self):
         pkg_name = self.pkg_with_non_ascii_description_egg_info(self.site_dir)
         meta = metadata(pkg_name)
-        assert meta['Description'] == 'pôrˈtend\n'
+        assert meta['Description'] == 'pôrˈtend'
 
 
 class DiscoveryTests(fixtures.EggInfoPkg, fixtures.DistInfoPkg, unittest.TestCase):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -162,7 +162,7 @@ class NonASCIITests(fixtures.OnSysPath, fixtures.SiteDir, unittest.TestCase):
     def test_metadata_loads_egg_info(self):
         pkg_name = self.pkg_with_non_ascii_description_egg_info(self.site_dir)
         meta = metadata(pkg_name)
-        assert meta.get_payload() == 'pôrˈtend\n'
+        assert meta['Description'] == 'pôrˈtend\n'
 
 
 class DiscoveryTests(fixtures.EggInfoPkg, fixtures.DistInfoPkg, unittest.TestCase):


### PR DESCRIPTION
Superseding #301 and #303, update the PackageMetadata protocol thus:

- Always provide a `Description` (even if found in the payload).
- Support multiline values for any field, even though the spec or build tools may still disallow it.
- For any multiline values, remove the line-continuation characters.
- Add a `json` property that converts the metadata into a JSON-compatible format per PEP 566.

Fixes #275, Fixes #276, Fixes #277.