### PR TITLE
Use os_helper to fix ImportError in Python 3.10

### DIFF
--- a/tests/py39compat.py
+++ b/tests/py39compat.py
@@ -1,4 +1,4 @@
 try:
-    from test.support.os_helpers import FS_NONASCII
+    from test.support.os_helper import FS_NONASCII
 except ImportError:
     from test.support import FS_NONASCII  # noqa


### PR DESCRIPTION
Running tests under Python 3.10 gives me below ImportError. It seems there is a typo and `os_helper` is the correct module : https://docs.python.org/3.10/library/test.html#module-test.support.os_helper

```
pytest -x
========================================================================= test session starts ==========================================================================
platform linux -- Python 3.10.0a0, pytest-6.2.3, py-1.10.0, pluggy-0.13.1
rootdir: /root/stuff/python/importlib_metadata, configfile: pytest.ini
plugins: flake8-1.0.7, pyfakefs-4.4.0, checkdocs-2.6.0, cov-2.11.1, enabler-1.2.0
collected 26 items / 1 error / 25 selected                                                                                                                             

================================================================================ ERRORS ================================================================================
__________________________________________________________________ ERROR collecting tests/fixtures.py __________________________________________________________________
tests/py39compat.py:2: in <module>
    from test.support.os_helpers import FS_NONASCII
E   ModuleNotFoundError: No module named 'test.support.os_helpers'

During handling of the above exception, another exception occurred:
tests/fixtures.py:10: in <module>
    from .py39compat import FS_NONASCII
tests/py39compat.py:4: in <module>
    from test.support import FS_NONASCII  # noqa
E   ImportError: cannot import name 'FS_NONASCII' from 'test.support' (/usr/local/lib/python3.10/test/support/__init__.py)
======================================================================= short test summary info ========================================================================
ERROR tests/fixtures.py - ImportError: cannot import name 'FS_NONASCII' from 'test.support' (/usr/local/lib/python3.10/test/support/__init__.py)
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! stopping after 1 failures !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
=========================================================================== 1 error in 0.33s ===========================================================================

```