### PR TITLE
meta: add SimplePath protocol for PathDistribution

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,9 @@
+v4.1.0
+=======
+
+* #315: Add ``SimplePath`` protocol for interface clarity
+  in ``PathDistribution``.
+
 v4.0.1
 =======
 

--- a/importlib_metadata/__init__.py
+++ b/importlib_metadata/__init__.py
@@ -15,7 +15,6 @@ import posixpath
 import collections
 
 from . import _adapters, _meta
-from ._meta import PackageMetadata, Path
 from ._collections import FreezableDefaultDict, Pair
 from ._compat import (
     NullFinder,
@@ -24,6 +23,7 @@ from ._compat import (
 )
 from ._functools import method_cache
 from ._itertools import unique_everseen
+from ._meta import PackageMetadata, Path
 
 from contextlib import suppress
 from importlib import import_module

--- a/importlib_metadata/__init__.py
+++ b/importlib_metadata/__init__.py
@@ -23,7 +23,7 @@ from ._compat import (
 )
 from ._functools import method_cache
 from ._itertools import unique_everseen
-from ._meta import PackageMetadata, Path
+from ._meta import PackageMetadata, SimplePath
 
 from contextlib import suppress
 from importlib import import_module
@@ -783,11 +783,10 @@ class MetadataPathFinder(NullFinder, DistributionFinder):
 
 
 class PathDistribution(Distribution):
-    def __init__(self, path: Path):
-        """Construct a distribution from a path to the metadata directory.
+    def __init__(self, path: SimplePath):
+        """Construct a distribution.
 
-        :param path: A pathlib.Path or similar object supporting
-                     .joinpath(), __div__, .parent, and .read_text().
+        :param path: SimplePath indicating the metadata directory.
         """
         self._path = path
 

--- a/importlib_metadata/__init__.py
+++ b/importlib_metadata/__init__.py
@@ -15,7 +15,7 @@ import posixpath
 import collections
 
 from . import _adapters, _meta
-from ._meta import PackageMetadata
+from ._meta import PackageMetadata, Path
 from ._collections import FreezableDefaultDict, Pair
 from ._compat import (
     NullFinder,
@@ -783,7 +783,7 @@ class MetadataPathFinder(NullFinder, DistributionFinder):
 
 
 class PathDistribution(Distribution):
-    def __init__(self, path):
+    def __init__(self, path: Path):
         """Construct a distribution from a path to the metadata directory.
 
         :param path: A pathlib.Path or similar object supporting

--- a/importlib_metadata/_meta.py
+++ b/importlib_metadata/_meta.py
@@ -30,14 +30,18 @@ class PackageMetadata(Protocol):
         """
 
 
-class Path(Protocol):
-    def joinpath(self) -> 'Path':
+class SimplePath(Protocol):
+    """
+    A minimal subset of pathlib.Path required by PathDistribution.
+    """
+
+    def joinpath(self) -> 'SimplePath':
         ...  # pragma: no cover
 
-    def __div__(self) -> 'Path':
+    def __div__(self) -> 'SimplePath':
         ...  # pragma: no cover
 
-    def parent(self) -> 'Path':
+    def parent(self) -> 'SimplePath':
         ...  # pragma: no cover
 
     def read_text(self) -> str:

--- a/importlib_metadata/_meta.py
+++ b/importlib_metadata/_meta.py
@@ -28,3 +28,17 @@ class PackageMetadata(Protocol):
         """
         A JSON-compatible form of the metadata.
         """
+
+
+class Path(Protocol):
+    def joinpath(self) -> 'Path':
+        ...  # pragma: no cover
+
+    def __div__(self) -> 'Path':
+        ...  # pragma: no cover
+
+    def parent(self) -> 'Path':
+        ...  # pragma: no cover
+
+    def read_text(self) -> str:
+        ...  # pragma: no cover


### PR DESCRIPTION
This is needed to properly annotate code that uses PathDistribution,
otherwise I need to keep redefining the protocol in my code.

Signed-off-by: Filipe Laíns <lains@riseup.net>