### PR TITLE
Use normalized names to distinguish unique distributions for performance

### DIFF
--- a/importlib_metadata/_compat.py
+++ b/importlib_metadata/_compat.py
@@ -15,6 +15,12 @@ except ImportError:  # pragma: no cover
     from typing_extensions import Protocol  # type: ignore
 
 
+if sys.version_info < (3, 7):
+    from singledispatch import singledispatch
+else:
+    from functools import singledispatch  # noqa: F401
+
+
 def install(cls):
     """
     Class decorator for installation on sys.meta_path.

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,6 +21,7 @@ python_requires = >=3.6
 install_requires =
 	zipp>=0.5
 	typing-extensions>=3.6.4; python_version < "3.8"
+	singledispatch; python_version < "3.7"
 
 [options.packages.find]
 exclude =


### PR DESCRIPTION
Fixes #283.

@anntzer Please have a look.

I found I couldn't use `path.stem` because `path` is a `SimplePath` and one implementation (`zipfile.Path`) doesn't implement `stem`.

I don't trust our benchmarks. Can you determine if this change has the performance benefit you were expecting?