### PR TITLE
Remove SelectableGroups deprecation exception for flake8.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,9 @@
+v4.5.0
+=======
+
+* #319: Remove ``SelectableGroups`` deprecation exception
+  for flake8.
+
 v4.4.0
 =======
 
@@ -16,8 +22,6 @@ v4.4.0
     for access by index. To avoid deprecation warnings,
     cast the result to a Sequence first
     (e.g. ``tuple(dist.entry_points)[0]``).
-
-* Remove SelectableGroups deprecation exception for flake8.
 
 v4.3.1
 =======

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,8 @@
+v4.3.0
+=======
+
+* Remove SelectableGroups deprecation exception for flake8.
+
 v4.2.0
 =======
 

--- a/importlib_metadata/__init__.py
+++ b/importlib_metadata/__init__.py
@@ -266,14 +266,6 @@ class EntryPoints(tuple):
         )
 
 
-def flake8_bypass(func):
-    # defer inspect import as performance optimization.
-    import inspect
-
-    is_flake8 = any('flake8' in str(frame.filename) for frame in inspect.stack()[:5])
-    return func if not is_flake8 else lambda: None
-
-
 class Deprecated:
     """
     Compatibility add-in for mapping to indicate that
@@ -309,7 +301,7 @@ class Deprecated:
         return super().__getitem__(name)
 
     def get(self, name, default=None):
-        flake8_bypass(self._warn)()
+        self._warn()
         return super().get(name, default)
 
     def __iter__(self):

--- a/pytest.ini
+++ b/pytest.ini
@@ -5,3 +5,5 @@ doctest_optionflags=ALLOW_UNICODE ELLIPSIS
 # workaround for warning pytest-dev/pytest#6178
 junit_family=xunit2
 filterwarnings=
+	# Suppress deprecation warning in flake8
+	ignore:SelectableGroups dict interface is deprecated::flake8


### PR DESCRIPTION
In #298 released with 3.6, this package introduced the `EntryPoints` objects with a `SelectableGroups` shim for compatibility with older usages. During the review, asottile, the maintainer of flake8 informed me that flake8 has a slow release cadence and that it would be disruptive to suddenly expose a DeprecationWarning in flake8, especially since some users of flake8 will have `-Werror` enabled.

In [merge request 464](https://github.com/PyCQA/flake8/issues/1004) and [merge request 472](https://github.com/PyCQA/flake8/issues/1011), I made attempts to update flake8 to transition to the new interface. Since both attempts were dismissed rapidly and without guidance on how to proceed and without response to my plea for conversation, I see no option but to press forward with the deprecation.

@asottile Is there anything you'd like to do before the deprecation is introduced for flake8 as it has for other projects?