### PR TITLE
bpo-44451: Reset DeprecationWarning filters in test_api.test_entry_points_by_index

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,10 @@
+v4.3.1
+=======
+
+* #320: Fix issue where normalized name for eggs was
+  incorrectly solicited, leading to metadata being
+  unavailable for eggs.
+
 v4.3.0
 =======
 

--- a/README.rst
+++ b/README.rst
@@ -40,7 +40,7 @@ were contributed to different versions in the standard library:
 
    * - importlib_metadata
      - stdlib
-   * - 3.10
+   * - 4.2
      - 3.10
    * - 1.4
      - 3.8

--- a/README.rst
+++ b/README.rst
@@ -40,7 +40,7 @@ were contributed to different versions in the standard library:
 
    * - importlib_metadata
      - stdlib
-   * - 4.2
+   * - 4.4
      - 3.10
    * - 1.4
      - 3.8

--- a/conftest.py
+++ b/conftest.py
@@ -1,4 +1,25 @@
+import sys
+
+
 collect_ignore = [
     # this module fails mypy tests because 'setup.py' matches './setup.py'
     'prepare/example/setup.py',
 ]
+
+
+def pytest_configure():
+    remove_importlib_metadata()
+
+
+def remove_importlib_metadata():
+    """
+    Because pytest imports importlib_metadata, the coverage
+    reports are broken (#322). So work around the issue by
+    undoing the changes made by pytest's import of
+    importlib_metadata (if any).
+    """
+    if sys.meta_path[-1].__class__.__name__ == 'MetadataPathFinder':
+        del sys.meta_path[-1]
+    for mod in list(sys.modules):
+        if mod.startswith('importlib_metadata'):
+            del sys.modules[mod]

--- a/importlib_metadata/__init__.py
+++ b/importlib_metadata/__init__.py
@@ -812,7 +812,17 @@ class PathDistribution(Distribution):
 
     @property
     def _normalized_name(self):
+        """
+        Performance optimization: where possible, resolve the
+        normalized name from the file system path.
+        """
         stem = os.path.basename(str(self._path))
+        return self._name_from_stem(stem) or super()._normalized_name
+
+    def _name_from_stem(self, stem):
+        name, ext = os.path.splitext(stem)
+        if ext not in ('.dist-info', '.egg-info'):
+            return
         name, sep, rest = stem.partition('-')
         return name
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -142,6 +142,7 @@ class APITests(
         """
         eps = distribution('distinfo-pkg').entry_points
         with warnings.catch_warnings(record=True) as caught:
+            warnings.filterwarnings("default", category=DeprecationWarning)
             eps[0]
 
         # check warning

--- a/tests/test_zip.py
+++ b/tests/test_zip.py
@@ -79,3 +79,7 @@ class TestEgg(TestZip):
         for file in files('example'):
             path = str(file.dist.locate_file(file))
             assert '.egg/' in path, path
+
+    def test_normalized_name(self):
+        dist = distribution('example')
+        assert dist._normalized_name == 'example'


### PR DESCRIPTION
This avoids the following error in CPython tests if DeprecationWarnings are ignored.

    ======================================================================
    ERROR: test_entry_points_by_index (test.test_importlib.test_metadata_api.APITests)
    Prior versions of Distribution.entry_points would return a
    ----------------------------------------------------------------------
    Traceback (most recent call last):
      File "/builddir/build/BUILD/Python-3.10.0b3/Lib/test/test_importlib/test_metadata_api.py", line 145, in test_entry_points_by_index
        expected = next(iter(caught))
    StopIteration
    ----------------------------------------------------------------------
    Ran 1402 tests in 2.125s
    FAILED (errors=1, skipped=18, expected failures=1)