### PR TITLE
export SimplePath

### DIFF
--- a/importlib_metadata/__init__.py
+++ b/importlib_metadata/__init__.py
@@ -38,6 +38,7 @@ __all__ = [
     'DistributionFinder',
     'PackageMetadata',
     'PackageNotFoundError',
+    'SimplePath',
     'distribution',
     'distributions',
     'entry_points',


### PR DESCRIPTION
mypy is not happy about us using an attribute that isn't explicitedly
exported.

Signed-off-by: Filipe Laíns <lains@riseup.net>