### PR TITLE
Implement EntryPoint._asdict

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,9 @@
+v4.7.0
+======
+
+* #337: ``EntryPoint`` objects now implement ``namedtuple._asdict``
+  to fulfill interface expecation of namedtuple objects.
+
 v4.6.4
 ======
 

--- a/importlib_metadata/__init__.py
+++ b/importlib_metadata/__init__.py
@@ -209,6 +209,10 @@ class EntryPoint(
         attrs = (getattr(self, param) for param in params)
         return all(map(operator.eq, params.values(), attrs))
 
+    def _asdict(self):
+        # override _asdict, broken by custom __iter__.
+        return {key: getattr(self, key) for key in self._fields}
+
 
 class DeprecatedList(list):
     """

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -180,6 +180,10 @@ class APITests(
             entry_points().get('entries', 'default') == entry_points()['entries']
             entry_points().get('missing', ()) == ()
 
+    def test_entry_point_as_dict(self):
+        ep = entry_points(group='entries')['main']
+        assert ep._asdict() == dict(name='main', group='entries', value='mod:main')
+
     def test_metadata_for_this_package(self):
         md = metadata('egginfo-pkg')
         assert md['author'] == 'Steven Ma'


### PR DESCRIPTION
In #337, Ronny reports a missed expectation - `EntryPoint` objects are constructed as `namedtuple` but fail to implement the `namedtuple._asdict` interface.

This change fulfills that expectation.