### PR TITLE
Remove FreezableDefaultDict

### DIFF
--- a/importlib_metadata/_collections.py
+++ b/importlib_metadata/_collections.py
@@ -1,29 +1,6 @@
 import collections
 
 
-# from jaraco.collections 3.3
-class FreezableDefaultDict(collections.defaultdict):
-    """
-    Often it is desirable to prevent the mutation of
-    a default dict after its initial construction, such
-    as to prevent mutation during iteration.
-
-    >>> dd = FreezableDefaultDict(list)
-    >>> dd[0].append('1')
-    >>> dd.freeze()
-    >>> dd[1]
-    []
-    >>> len(dd)
-    1
-    """
-
-    def __missing__(self, key):
-        return getattr(self, '_frozen', super().__missing__)(key)
-
-    def freeze(self):
-        self._frozen = lambda key: self.default_factory()
-
-
 class Pair(collections.namedtuple('Pair', 'name value')):
     @classmethod
     def parse(cls, text):


### PR DESCRIPTION
As you can see from this diff, `FreezableDefaultDict` doesn’t seem like it’s adding much value over a regular `dict` for this use case. What do you think about removing it, as a simpler alternative to addressing [these comments](https://github.com/python/importlib_metadata/pull/342#pullrequestreview-739810818) from #342?