### PR TITLE
Remove unique_everseen

### DIFF
--- a/importlib_metadata/_itertools.py
+++ b/importlib_metadata/_itertools.py
@@ -1,24 +1,3 @@
-from itertools import filterfalse
-
-
-def unique_everseen(iterable, key=None):
-    "List unique elements, preserving order. Remember all elements ever seen."
-    # unique_everseen('AAAABBBCCDAABBB') --> A B C D
-    # unique_everseen('ABBCcAD', str.lower) --> A B C D
-    seen = set()
-    seen_add = seen.add
-    if key is None:
-        for element in filterfalse(seen.__contains__, iterable):
-            seen_add(element)
-            yield element
-    else:
-        for element in iterable:
-            k = key(element)
-            if k not in seen:
-                seen_add(k)
-                yield element
-
-
 # copied from more_itertools 8.8
 def always_iterable(obj, base_type=(str, bytes)):
     """If *obj* is iterable, return an iterator over its items::


### PR DESCRIPTION
`unique_everseen` has some clever optimizations, but only for the `key=None` case that we don’t use. What do you think about removing it, as a simpler alternative to addressing https://github.com/python/importlib_metadata/pull/342#pullrequestreview-739817818?