### PR TITLE
Restore support for EntryPoint access by item.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,15 @@
+v4.8.1
+======
+
+* #348: Restored support for ``EntryPoint`` access by item,
+  deprecating support in the process. Users are advised
+  to use direct member access instead of item-based access::
+
+  - ep[0] -> ep.name
+  - ep[1] -> ep.value
+  - ep[2] -> ep.group
+  - ep[:] -> ep.name, ep.value, ep.group
+
 v4.8.0
 ======
 

--- a/importlib_metadata/__init__.py
+++ b/importlib_metadata/__init__.py
@@ -125,7 +125,33 @@ class Sectioned:
         return line and not line.startswith('#')
 
 
-class EntryPoint:
+class DeprecatedTuple:
+    """
+    Provide subscript item access for backward compatibility.
+
+    >>> recwarn = getfixture('recwarn')
+    >>> ep = EntryPoint(name='name', value='value', group='group')
+    >>> ep[:]
+    ('name', 'value', 'group')
+    >>> ep[0]
+    'name'
+    >>> len(recwarn)
+    1
+    """
+
+    _warn = functools.partial(
+        warnings.warn,
+        "EntryPoint tuple interface is deprecated. Access members by name.",
+        DeprecationWarning,
+        stacklevel=pypy_partial(2),
+    )
+
+    def __getitem__(self, item):
+        self._warn()
+        return self._key()[item]
+
+
+class EntryPoint(DeprecatedTuple):
     """An entry point as defined by Python packaging conventions.
 
     See `the packaging docs on entry points


### PR DESCRIPTION
Fixes #348.

Restored support is immediately deprecated, providing guidance on achieving zen (preferably one obvious way) w.r.t. member access.