### PR TITLE
metadata: remove Distribution._local

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,13 @@
+v4.9.0
+======
+
+* #354: Removed ``Distribution._local`` factory. This
+  functionality was created as a demonstration of the
+  possible implementation. Now, the
+  `pep517 <https://pypi.org/project/pep517>`_ package
+  provides this functionality directly through
+  `pep517.meta.load <https://github.com/pypa/pep517/blob/a942316305395f8f757f210e2b16f738af73f8b8/pep517/meta.py#L63-L73>`_.
+
 v4.8.1
 ======
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,14 +10,12 @@ versions of Python), this can eliminate the need to use the older and less
 efficient ``pkg_resources`` package.
 
 ``importlib_metadata`` supplies a backport of
-:doc:`importlib.metadata <library/importlib.metadata>` as found in
-Python 3.8 and later for earlier Python releases.  Users of
-Python 3.8 and beyond are encouraged to use the standard library module
-when possible and fall back to ``importlib_metadata`` when necessary.
-When imported on Python 3.8 and later, ``importlib_metadata`` replaces the
-DistributionFinder behavior from the stdlib, but leaves the API in tact.
-Developers looking for detailed API descriptions should refer to the Python
-3.8 standard library documentation.
+:doc:`importlib.metadata <library/importlib.metadata>`,
+enabling early access to features of future Python versions and making
+functionality available for older Python versions. Users are encouraged to
+use the Python standard library where suitable and fall back to
+this library for future compatibility. Developers looking for detailed API
+descriptions should refer to the standard library documentation.
 
 The documentation here includes a general :ref:`usage <using>` guide.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,9 +4,9 @@ Welcome to |project| documentation!
 ``importlib_metadata`` is a library which provides an API for accessing an
 installed package's metadata (see :pep:`566`), such as its entry points or its top-level
 name.  This functionality intends to replace most uses of ``pkg_resources``
-`entry point API`_ and `metadata API`_.  Along with :mod:`importlib.resources` in
-Python 3.7 and newer (backported as :doc:`importlib_resources <importlib_resources:index>` for older
-versions of Python), this can eliminate the need to use the older and less
+`entry point API`_ and `metadata API`_.  Along with :mod:`importlib.resources`
+and newer (backported as :doc:`importlib_resources <importlib_resources:index>`),
+this package can eliminate the need to use the older and less
 efficient ``pkg_resources`` package.
 
 ``importlib_metadata`` supplies a backport of

--- a/importlib_metadata/__init__.py
+++ b/importlib_metadata/__init__.py
@@ -576,18 +576,6 @@ class Distribution:
         )
         return filter(None, declared)
 
-    @classmethod
-    def _local(cls, root='.'):
-        from pep517 import build, meta
-
-        system = build.compat_system(root)
-        builder = functools.partial(
-            meta.build,
-            source_dir=root,
-            system=system,
-        )
-        return PathDistribution(zipp.Path(meta.build_as_zip(builder)))
-
     @property
     def metadata(self) -> _meta.PackageMetadata:
         """Return the parsed metadata for this Distribution.

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,7 +46,6 @@ testing =
 	# local
 	importlib_resources>=1.3; python_version < "3.9"
 	packaging
-	pep517
 	pyfakefs
 	flufl.flake8
 	pytest-perf >= 0.9.2

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -231,21 +231,6 @@ class EggInfoFile(OnSysPath, SiteDir):
         build_files(EggInfoFile.files, prefix=self.site_dir)
 
 
-class LocalPackage:
-    files: FilesDef = {
-        "setup.py": """
-            import setuptools
-            setuptools.setup(name="local-pkg", version="2.0.1")
-            """,
-    }
-
-    def setUp(self):
-        self.fixtures = contextlib.ExitStack()
-        self.addCleanup(self.fixtures.close)
-        self.fixtures.enter_context(tempdir_as_cwd())
-        build_files(self.files)
-
-
 def build_files(file_defs, prefix=pathlib.Path()):
     """Build a set of files/directories, as described by the
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -4,7 +4,6 @@ import packaging.version
 
 from . import fixtures
 from importlib_metadata import (
-    Distribution,
     MetadataPathFinder,
     _compat,
     distributions,

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -44,13 +44,6 @@ class FinderTests(fixtures.Fixtures, unittest.TestCase):
         _compat.disable_stdlib_finder()
 
 
-class LocalProjectTests(fixtures.LocalPackage, unittest.TestCase):
-    def test_find_local(self):
-        dist = Distribution._local()
-        assert dist.metadata['Name'] == 'local-pkg'
-        assert dist.version == '2.0.1'
-
-
 class DistSearch(unittest.TestCase):
     def test_search_dist_dirs(self):
         """


### PR DESCRIPTION
Importing an external module is anti-pattern and very unexpected
behavior. Furthermore, the specific builder implementation we are using
will provision an isolated virtual environmnent and perform the build
there, which is unwanted in various scenarious.

Perhaps there was a time this helper was needed, but we can now
remove this in favor of build.util.project_wheel_metadata[1].

[1] https://github.com/pypa/build/blob/82051d509a87124a46f3766134c11fc8aee9b86a/src/build/util.py#L27

Signed-off-by: Filipe Laíns <lains@riseup.net>