### PR TITLE
ensure the arg to re.sub is a string object

### DIFF
--- a/importlib_metadata/__init__.py
+++ b/importlib_metadata/__init__.py
@@ -856,7 +856,7 @@ class Prepared:
         """
         PEP 503 normalization plus dashes as underscores.
         """
-        return re.sub(r"[-_.]+", "-", name).lower().replace('-', '_')
+        return re.sub(r"[-_.]+", "-", str(name)).lower().replace('-', '_')
 
     @staticmethod
     def legacy_normalize(name):


### PR DESCRIPTION
hi
for me, this fixes build failures of firefox, gimp and matplotlib with the error message:

```expected string or bytes-like object```