### PR TITLE
Do not leak `method_name` in `DeprecatedList`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,9 @@
+v4.10.2
+=======
+
+* #365 and bpo-46546: Avoid leaking ``method_name`` in
+  ``DeprecatedList``.
+
 v4.10.1
 =======
 

--- a/importlib_metadata/__init__.py
+++ b/importlib_metadata/__init__.py
@@ -295,22 +295,15 @@ class DeprecatedList(list):
             self._warn()
             return getattr(super(), method_name)(*args, **kwargs)
 
-        return wrapped
+        return method_name, wrapped
 
-    for method_name in [
-        '__setitem__',
-        '__delitem__',
-        'append',
-        'reverse',
-        'extend',
-        'pop',
-        'remove',
-        '__iadd__',
-        'insert',
-        'sort',
-    ]:
-        locals()[method_name] = _wrap_deprecated_method(method_name)
-    del method_name
+    locals().update(
+        map(
+            _wrap_deprecated_method,
+            '__setitem__ __delitem__ append reverse extend pop remove '
+            '__iadd__ insert sort'.split(),
+        )
+    )
 
     def __add__(self, other):
         if not isinstance(other, tuple):

--- a/importlib_metadata/__init__.py
+++ b/importlib_metadata/__init__.py
@@ -310,6 +310,7 @@ class DeprecatedList(list):
         'sort',
     ]:
         locals()[method_name] = _wrap_deprecated_method(method_name)
+    del method_name
 
     def __add__(self, other):
         if not isinstance(other, tuple):


### PR DESCRIPTION
Refs https://bugs.python.org/issue46546