### PR TITLE
Add support for resolving dependencies (declared and missing) for an EntryPoint.

### DIFF
--- a/importlib_metadata/__init__.py
+++ b/importlib_metadata/__init__.py
@@ -189,7 +189,7 @@ class Deps(set):
             req
             for req in map(Requirement, always_iterable(ep.dist.requires))
             for extra in ep.extras
-            if req.marker.evaluate(dict(extra=extra))
+            if req.marker and req.marker.evaluate(dict(extra=extra))
         )
 
 

--- a/importlib_metadata/__init__.py
+++ b/importlib_metadata/__init__.py
@@ -155,6 +155,7 @@ class Deps(set):
     """
     A set of packaging.requirement.Requirements.
     """
+
     @property
     def missing(self):
         """
@@ -251,6 +252,7 @@ class EntryPoint(DeprecatedTuple):
         with this entry point. Requires self.dist to be defined.
         """
         from packaging.requirements import Requirement
+
         return Deps(
             req
             for req in map(Requirement, always_iterable(self.dist.requires))

--- a/importlib_metadata/__init__.py
+++ b/importlib_metadata/__init__.py
@@ -184,6 +184,7 @@ class Deps(set):
         Requires ep.dist to be defined.
         """
         from packaging.requirements import Requirement
+
         return cls(
             req
             for req in map(Requirement, always_iterable(ep.dist.requires))

--- a/tests/py39compat.py
+++ b/tests/py39compat.py
@@ -2,3 +2,9 @@ try:
     from test.support.os_helper import FS_NONASCII
 except ImportError:
     from test.support import FS_NONASCII  # noqa
+
+
+try:
+    from test.support.import_helper import import_module
+except ImportError:
+    from test.support import import_module  # noqa

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -16,6 +16,7 @@ from importlib_metadata import (
     requires,
     version,
 )
+from .py39compat import import_module
 
 
 @contextlib.contextmanager
@@ -186,11 +187,13 @@ class APITests(
             ep.foo = 4
 
     def test_entry_points_deps_basic(self):
+        import_module('packaging')
         ep = next(iter(entry_points().select(group='entries', name='main')))
         assert list(ep.deps) == []
         assert list(ep.deps.missing) == []
 
     def test_entry_points_deps(self):
+        import_module('packaging')
         alt_site_dir = self.fixtures.enter_context(fixtures.tempdir())
         self.fixtures.enter_context(self.add_sys_path(alt_site_dir))
         eps_pkg = {

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -209,9 +209,9 @@ class APITests(
         }
         fixtures.build_files(eps_pkg, alt_site_dir)
         (ep,) = entry_points().select(group='entries', name='tester')
-        expected_deps = ['pytest; extra == "test"', 'does-not-exist; extra == "other"']
-        assert list(map(str, ep.deps)) == expected_deps
-        assert list(map(str, ep.deps.missing)) == ['does-not-exist; extra == "other"']
+        expected_deps = {'pytest; extra == "test"', 'does-not-exist; extra == "other"'}
+        assert set(map(str, ep.deps)) == expected_deps
+        assert set(map(str, ep.deps.missing)) == {'does-not-exist; extra == "other"'}
 
     def test_metadata_for_this_package(self):
         md = metadata('egginfo-pkg')

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -193,6 +193,17 @@ class APITests(
         assert list(ep.deps.missing) == []
 
     def test_entry_points_deps(self):
+        """
+        Capture several expectations around dependencies.
+
+        Consider splitting these into separate unit tests.
+
+        1. Multiple extras will be checked.
+        2. Satisfied extras will be excluded from 'missing' (pytest).
+        3. Missing dependencies will be reported (does-not-exist).
+        4. Dependencies not listing extras (tempora) will not
+           break the check.
+        """
         import_module('packaging')
         alt_site_dir = self.fixtures.enter_context(fixtures.tempdir())
         self.fixtures.enter_context(self.add_sys_path(alt_site_dir))
@@ -203,6 +214,7 @@ class APITests(
                 Version: 1.1.0
                 Requires-Dist: pytest; extra == 'test'
                 Requires-Dist: does-not-exist; extra == 'other'
+                Requires-Dist: tempora
                 """,
                 "entry_points.txt": """
                 [entries]


### PR DESCRIPTION
- Add basic degenerate tests for EntryPoint.deps.
- Add EntryPoint.deps for resolving all and missing deps for any entry point. Fixes #368.
- packaging is required to parse extras.
- Add meaningful test for EntryPoints.deps.
- ⚫ Fade to black.
- ⚫ Fade to black.
- Ignore order in expected deps
- Skip relevant tests when packaging is unavailable.
