### PR TITLE
fix `PathDistribution._normalized_name` implementation

### DIFF
--- a/importlib_metadata/__init__.py
+++ b/importlib_metadata/__init__.py
@@ -956,7 +956,10 @@ class PathDistribution(Distribution):
         normalized name from the file system path.
         """
         stem = os.path.basename(str(self._path))
-        return self._name_from_stem(stem) or super()._normalized_name
+        return (
+            pass_none(Prepared.normalize)(self._name_from_stem(stem))
+            or super()._normalized_name
+        )
 
     @staticmethod
     def _name_from_stem(stem):


### PR DESCRIPTION
- correctly handle paths with no embedded version (e.g. `pkg.egg-info` must yield the name `pkg`, not `pkg.egg`)
- apply PEP 503 normalization to the extracted names (e.g.: `zope..inter_face-4.2.dist-info` must yield the name `zope_inter_face`)

Both are necessary, or `entry_points(…)` can yield the entry-points of a shadowed distribution. For example: with a version of `mypkg` in the system' site-packages directory when working from another development checkout of the same package (with a `mypgk.egg-info` directory mishandled by the first bug).
