### PR TITLE
Fix filesystem path distribution name inference parsing.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,9 @@
+v4.11.4
+=======
+
+* #377: In ``PathDistribution._name_from_stem``, avoid including
+  parts of the extension in the result.
+
 v4.11.3
 =======
 

--- a/importlib_metadata/__init__.py
+++ b/importlib_metadata/__init__.py
@@ -960,6 +960,14 @@ class PathDistribution(Distribution):
 
     @staticmethod
     def _name_from_stem(stem):
+        """
+        >>> PathDistribution._name_from_stem('foo-3.0.egg-info')
+        'foo'
+        >>> PathDistribution._name_from_stem('CherryPy-3.0.dist-info')
+        'CherryPy'
+        >>> PathDistribution._name_from_stem('face.egg-info')
+        'face'
+        """
         _, ext = os.path.splitext(stem)
         if ext not in ('.dist-info', '.egg-info'):
             return

--- a/importlib_metadata/__init__.py
+++ b/importlib_metadata/__init__.py
@@ -968,10 +968,10 @@ class PathDistribution(Distribution):
         >>> PathDistribution._name_from_stem('face.egg-info')
         'face'
         """
-        _, ext = os.path.splitext(stem)
+        filename, ext = os.path.splitext(stem)
         if ext not in ('.dist-info', '.egg-info'):
             return
-        name, sep, rest = stem.partition('-')
+        name, sep, rest = filename.partition('-')
         return name
 
 

--- a/importlib_metadata/__init__.py
+++ b/importlib_metadata/__init__.py
@@ -958,8 +958,9 @@ class PathDistribution(Distribution):
         stem = os.path.basename(str(self._path))
         return self._name_from_stem(stem) or super()._normalized_name
 
-    def _name_from_stem(self, stem):
-        name, ext = os.path.splitext(stem)
+    @staticmethod
+    def _name_from_stem(stem):
+        _, ext = os.path.splitext(stem)
         if ext not in ('.dist-info', '.egg-info'):
             return
         name, sep, rest = stem.partition('-')


### PR DESCRIPTION
- Removed shadowed variable and make _name_from_stem a staticmethod.
- Add some (failing) tests for _name_from_stem. Ref #377
- Fix issue when metadata on the file system has no version. No more egg on face. Ref #377.
- Update changelog. Ref #377.
