### PR TITLE
Validate name arg in Distribution.from_name

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,10 @@
+v4.12.0
+=======
+
+* py-93259: Now raise ``ValueError`` when ``None`` or an empty
+  string are passed to ``Distribution.from_name`` (and other
+  callers).
+
 v4.11.4
 =======
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,6 +20,10 @@ link_files = {
                 pattern=r'PEP[- ](?P<pep_number>\d+)',
                 url='https://peps.python.org/pep-{pep_number:0>4}/',
             ),
+            dict(
+                pattern=r'(Python #|py-)(?P<python>\d+)',
+                url='https://github.com/python/cpython/issues/{python}',
+            ),
         ],
     )
 }

--- a/importlib_metadata/__init__.py
+++ b/importlib_metadata/__init__.py
@@ -548,7 +548,7 @@ class Distribution:
         """
 
     @classmethod
-    def from_name(cls, name):
+    def from_name(cls, name: str):
         """Return the Distribution for the given package name.
 
         :param name: The name of the distribution package to search for.
@@ -556,7 +556,10 @@ class Distribution:
             package, if found.
         :raises PackageNotFoundError: When the named package's distribution
             metadata cannot be found.
+        :raises ValueError: When an invalid value is supplied for name.
         """
+        if not name:
+            raise ValueError("A distribution name is required.")
         for resolver in cls._discover_resolvers():
             dists = resolver(DistributionFinder.Context(name=name))
             dist = next(iter(dists), None)

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -5,6 +5,7 @@ import shutil
 import pathlib
 import tempfile
 import textwrap
+import functools
 import contextlib
 
 from .py39compat import FS_NONASCII
@@ -294,3 +295,18 @@ class ZipFixtures:
         # Add self.zip_name to the front of sys.path.
         self.resources = contextlib.ExitStack()
         self.addCleanup(self.resources.close)
+
+
+def parameterize(*args_set):
+    """Run test method with a series of parameters."""
+
+    def wrapper(func):
+        @functools.wraps(func)
+        def _inner(self):
+            for args in args_set:
+                with self.subTest(**args):
+                    func(self, **args)
+
+        return _inner
+
+    return wrapper

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,6 +1,7 @@
 import re
 import json
 import pickle
+import pytest
 import unittest
 import warnings
 import importlib
@@ -49,6 +50,15 @@ class BasicTests(fixtures.DistInfoPkg, unittest.TestCase):
     def test_new_style_classes(self):
         self.assertIsInstance(Distribution, type)
         self.assertIsInstance(MetadataPathFinder, type)
+
+    @pytest.mark.xfail(reason="Not implemented")
+    @fixtures.parameterize(
+        dict(name=None),
+        dict(name=''),
+    )
+    def test_invalid_inputs_to_from_name(self, name):
+        with self.assertRaises(Exception):
+            Distribution.from_name(name)
 
 
 class ImportTests(fixtures.DistInfoPkg, unittest.TestCase):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,7 +1,6 @@
 import re
 import json
 import pickle
-import pytest
 import unittest
 import warnings
 import importlib
@@ -51,7 +50,6 @@ class BasicTests(fixtures.DistInfoPkg, unittest.TestCase):
         self.assertIsInstance(Distribution, type)
         self.assertIsInstance(MetadataPathFinder, type)
 
-    @pytest.mark.xfail(reason="Not implemented")
     @fixtures.parameterize(
         dict(name=None),
         dict(name=''),


### PR DESCRIPTION
- Add xfail test capturing new expectation.
- In Distribution.from_name, require a non-empty string. Fixes python/cpython#93259.
