### PR TITLE
Make "pip install --no-binary" possible on Python 3.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,9 @@
 [build-system]
-requires = ["setuptools>=56", "setuptools_scm[toml]>=3.4.1"]
+requires = [
+    "setuptools>=56",
+    "setuptools_scm[toml]>=3.4.1 ; python_version >= '3.8'",
+    "setuptools_scm[toml]>=3.4.1,<7.0.0 ; python_version < '3.8'",
+]
 build-backend = "setuptools.build_meta"
 
 [tool.black]


### PR DESCRIPTION
Resolves #392

Avoid a recursion error when running `pip install --no-binary` for `python_version < "3.8"`.