### PR TITLE
Add compatibility for `PathDistributions` implemented with stdlib objects in Python 3.8/3.9

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,6 +16,11 @@ jobs:
         - ubuntu-latest
         - macos-latest
         - windows-latest
+        include:
+        - platform: ubuntu-latest
+          python: ~3.8.0-0
+        - platform: ubuntu-latest
+          python: ~3.9.0-0
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v3

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,9 @@
+v4.13.0
+=======
+
+* #396: Added compatibility for ``PathDistributions`` originating
+  from Python 3.8 and 3.9.
+
 v4.12.0
 =======
 

--- a/importlib_metadata/__init__.py
+++ b/importlib_metadata/__init__.py
@@ -29,7 +29,7 @@ from contextlib import suppress
 from importlib import import_module
 from importlib.abc import MetaPathFinder
 from itertools import starmap
-from typing import List, Mapping, Optional, Tuple, Union, cast
+from typing import List, Mapping, Optional, Tuple, Union
 
 
 __all__ = [
@@ -1038,12 +1038,7 @@ def _compat_normalized_name(dist: Distribution) -> Optional[str]:
     try:
         return dist._normalized_name
     except AttributeError:
-        if "PathDistribution" in dist.__class__.__name__:
-            dist_ = cast(PathDistribution, dist)  # old implementation
-            return PathDistribution(dist_._path)._normalized_name
-        elif hasattr(dist, "name"):
-            return Prepared.normalize(dist.name)
-        raise
+        return Prepared.normalize(getattr(dist, "name", dist.metadata['Name']))
 
 
 _unique = functools.partial(

--- a/importlib_metadata/__init__.py
+++ b/importlib_metadata/__init__.py
@@ -189,6 +189,10 @@ class EntryPoint(DeprecatedTuple):
     following the attr, and following any extras.
     """
 
+    name: str
+    value: str
+    group: str
+
     dist: Optional['Distribution'] = None
 
     def __init__(self, name, value, group):

--- a/importlib_metadata/__init__.py
+++ b/importlib_metadata/__init__.py
@@ -1038,7 +1038,7 @@ def _compat_normalized_name(dist: Distribution) -> Optional[str]:
     try:
         return dist._normalized_name
     except AttributeError:
-        return Prepared.normalize(getattr(dist, "name", dist.metadata['Name']))
+        return Prepared.normalize(getattr(dist, "name", None) or dist.metadata['Name'])
 
 
 _unique = functools.partial(

--- a/importlib_metadata/__init__.py
+++ b/importlib_metadata/__init__.py
@@ -1015,9 +1015,18 @@ def version(distribution_name):
     return distribution(distribution_name).version
 
 
+def _compat_normalized_name(dist: Distribution) -> Optional[str]:
+    """
+    Compatibility layer that honor name normalization for distributions
+    that don't provide ``_normalized_name``
+    (as in ``importlib.metadata`` for Python 3.8/3.9).
+    """
+    return getattr(dist, '_normalized_name', None) or Prepared.normalize(dist.name)
+
+
 _unique = functools.partial(
     unique_everseen,
-    key=operator.attrgetter('_normalized_name'),
+    key=_compat_normalized_name,
 )
 """
 Wrapper for ``distributions`` to return unique distributions by name.

--- a/importlib_metadata/_py39compat.py
+++ b/importlib_metadata/_py39compat.py
@@ -3,7 +3,8 @@ Compatibility layer with Python 3.8/3.9
 """
 from typing import TYPE_CHECKING, Any, Optional, Tuple
 
-if TYPE_CHECKING:  # -> prevent circular imports on runtime.
+if TYPE_CHECKING:  # pragma: no cover
+    # Prevent circular imports on runtime.
     from . import Distribution, EntryPoint
 else:
     Distribution = EntryPoint = Any

--- a/importlib_metadata/_py39compat.py
+++ b/importlib_metadata/_py39compat.py
@@ -1,0 +1,48 @@
+"""
+Compatibility layer with Python 3.8/3.9
+"""
+from typing import TYPE_CHECKING, Any, Optional, Tuple
+
+
+if TYPE_CHECKING:
+    from . import Distribution, EntryPoint
+else:
+    Distribution = EntryPoint = Any
+
+
+def normalized_name(dist: Distribution) -> Optional[str]:
+    """
+    Honor name normalization for distributions that don't provide ``_normalized_name``.
+    """
+    try:
+        return dist._normalized_name
+    except AttributeError:
+        from . import Prepared
+
+        return Prepared.normalize(getattr(dist, "name", None) or dist.metadata['Name'])
+
+
+def ep_matches(ep: EntryPoint, **params) -> Tuple[EntryPoint, bool]:
+    """
+    Workaround for ``EntryPoint`` objects without the ``matches`` method.
+    For the sake of convenience, a tuple is returned containing not only the
+    boolean value corresponding to the predicate evalutation, but also a compatible
+    ``EntryPoint`` object that can be safely used at a later stage.
+
+    For example, the following sequences of expressions should be compatible:
+
+        # Sequence 1: using the compatibility layer
+        candidates = (_py39compat.ep_matches(ep, **params) for ep in entry_points)
+        [ep for ep, predicate in candidates if predicate]
+
+        # Sequence 2: using Python 3.9+
+        [ep for ep in entry_points if ep.matches(**params)]
+    """
+    try:
+        return ep, ep.matches(**params)
+    except AttributeError:
+        from . import EntryPoint
+
+        # Reconstruct the EntryPoint object to make sure it is compatible.
+        _ep = EntryPoint(ep.name, ep.value, ep.group)
+        return _ep, _ep.matches(**params)

--- a/importlib_metadata/_py39compat.py
+++ b/importlib_metadata/_py39compat.py
@@ -3,8 +3,7 @@ Compatibility layer with Python 3.8/3.9
 """
 from typing import TYPE_CHECKING, Any, Optional, Tuple
 
-
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # -> prevent circular imports on runtime.
     from . import Distribution, EntryPoint
 else:
     Distribution = EntryPoint = Any
@@ -17,7 +16,7 @@ def normalized_name(dist: Distribution) -> Optional[str]:
     try:
         return dist._normalized_name
     except AttributeError:
-        from . import Prepared
+        from . import Prepared  # -> delay to prevent circular imports.
 
         return Prepared.normalize(getattr(dist, "name", None) or dist.metadata['Name'])
 
@@ -41,7 +40,7 @@ def ep_matches(ep: EntryPoint, **params) -> Tuple[EntryPoint, bool]:
     try:
         return ep, ep.matches(**params)
     except AttributeError:
-        from . import EntryPoint
+        from . import EntryPoint  # -> delay to prevent circular imports.
 
         # Reconstruct the EntryPoint object to make sure it is compatible.
         _ep = EntryPoint(ep.name, ep.value, ep.group)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -8,10 +8,7 @@ from . import fixtures
 from importlib_metadata import (
     MetadataPathFinder,
     _compat,
-    distribution,
     distributions,
-    entry_points,
-    metadata,
     version,
 )
 
@@ -46,68 +43,6 @@ class FinderTests(fixtures.Fixtures, unittest.TestCase):
 
         self.fixtures.enter_context(fixtures.install_finder(ModuleFreeFinder()))
         _compat.disable_stdlib_finder()
-
-
-class OldStdlibFinderTests(fixtures.DistInfoPkgOffPath, unittest.TestCase):
-    def setUp(self):
-        python_version = sys.version_info[:2]
-        if python_version < (3, 8) or python_version > (3, 9):
-            self.skipTest("Tests specific for Python 3.8/3.9")
-        super().setUp()
-
-    def _meta_path_finder(self):
-        from importlib.metadata import (
-            Distribution,
-            DistributionFinder,
-            PathDistribution,
-        )
-        from importlib.util import spec_from_file_location
-
-        path = pathlib.Path(self.site_dir)
-
-        class CustomDistribution(Distribution):
-            def __init__(self, name, path):
-                self.name = name
-                self._path_distribution = PathDistribution(path)
-
-            def read_text(self, filename):
-                return self._path_distribution.read_text(filename)
-
-            def locate_file(self, path):
-                return self._path_distribution.locate_file(path)
-
-        class CustomFinder:
-            @classmethod
-            def find_spec(cls, fullname, _path=None, _target=None):
-                candidate = pathlib.Path(path, *fullname.split(".")).with_suffix(".py")
-                if candidate.exists():
-                    return spec_from_file_location(fullname, candidate)
-
-            @classmethod
-            def find_distributions(self, context=DistributionFinder.Context()):
-                for dist_info in path.glob("*.dist-info"):
-                    yield PathDistribution(dist_info)
-                    name, _, _ = str(dist_info).partition("-")
-                    yield CustomDistribution(name + "_custom", dist_info)
-
-        return CustomFinder
-
-    def test_compatibility_with_old_stdlib_path_distribution(self):
-        """
-        Given a custom finder that uses Python 3.8/3.9 importlib.metadata is installed,
-        when importlib_metadata functions are called, there should be no exceptions.
-        Ref python/importlib_metadata#396.
-        """
-        self.fixtures.enter_context(fixtures.install_finder(self._meta_path_finder()))
-
-        assert list(distributions())
-        assert distribution("distinfo_pkg")
-        assert distribution("distinfo_pkg_custom")
-        assert version("distinfo_pkg") > "0"
-        assert version("distinfo_pkg_custom") > "0"
-        assert list(metadata("distinfo_pkg"))
-        assert list(metadata("distinfo_pkg_custom"))
-        assert list(entry_points(group="entries"))
 
 
 class DistSearch(unittest.TestCase):

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,5 +1,3 @@
-import sys
-import pathlib
 import unittest
 import packaging.requirements
 import packaging.version

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,3 +1,5 @@
+import sys
+import pathlib
 import unittest
 import packaging.requirements
 import packaging.version
@@ -6,7 +8,10 @@ from . import fixtures
 from importlib_metadata import (
     MetadataPathFinder,
     _compat,
+    distribution,
     distributions,
+    entry_points,
+    metadata,
     version,
 )
 
@@ -41,6 +46,48 @@ class FinderTests(fixtures.Fixtures, unittest.TestCase):
 
         self.fixtures.enter_context(fixtures.install_finder(ModuleFreeFinder()))
         _compat.disable_stdlib_finder()
+
+
+class OldStdlibFinderTests(fixtures.DistInfoPkgOffPath, unittest.TestCase):
+    def setUp(self):
+        python_version = sys.version_info[:2]
+        if python_version < (3, 8) or python_version > (3, 9):
+            self.skipTest("Tests specific for Python 3.8/3.9")
+        super().setUp()
+
+    def _meta_path_finder(self):
+        from importlib.metadata import DistributionFinder, PathDistribution
+        from importlib.util import spec_from_file_location
+
+        path = pathlib.Path(self.site_dir)
+
+        class CustomFinder:
+            @classmethod
+            def find_spec(cls, fullname, _path=None, _target=None):
+                candidate = pathlib.Path(path, *fullname.split(".")).with_suffix(".py")
+                if candidate.exists():
+                    return spec_from_file_location(fullname, candidate)
+
+            @classmethod
+            def find_distributions(self, context=DistributionFinder.Context()):
+                for dist_info in path.glob("*.dist-info"):
+                    yield PathDistribution(dist_info)
+
+        return CustomFinder
+
+    def test_compatibility_with_old_stdlib_path_distribution(self):
+        """
+        Given a custom finder that uses Python 3.8/3.9 importlib.metadata is installed,
+        when importlib_metadata functions are called, there should be no exceptions.
+        Ref python/importlib_metadata#396.
+        """
+        self.fixtures.enter_context(fixtures.install_finder(self._meta_path_finder()))
+
+        assert list(distributions())
+        assert distribution("distinfo_pkg")
+        assert version("distinfo_pkg") > "0"
+        assert list(metadata("distinfo_pkg"))
+        assert list(entry_points(group="entries"))
 
 
 class DistSearch(unittest.TestCase):

--- a/tests/test_py39compat.py
+++ b/tests/test_py39compat.py
@@ -1,0 +1,74 @@
+import sys
+import unittest
+import pathlib
+
+from . import fixtures
+from importlib_metadata import (
+    distribution,
+    distributions,
+    entry_points,
+    metadata,
+    version,
+)
+
+
+class OldStdlibFinderTests(fixtures.DistInfoPkgOffPath, unittest.TestCase):
+    def setUp(self):
+        python_version = sys.version_info[:2]
+        if python_version < (3, 8) or python_version > (3, 9):
+            self.skipTest("Tests specific for Python 3.8/3.9")
+        super().setUp()
+
+    def _meta_path_finder(self):
+        from importlib.metadata import (
+            Distribution,
+            DistributionFinder,
+            PathDistribution,
+        )
+        from importlib.util import spec_from_file_location
+
+        path = pathlib.Path(self.site_dir)
+
+        class CustomDistribution(Distribution):
+            def __init__(self, name, path):
+                self.name = name
+                self._path_distribution = PathDistribution(path)
+
+            def read_text(self, filename):
+                return self._path_distribution.read_text(filename)
+
+            def locate_file(self, path):
+                return self._path_distribution.locate_file(path)
+
+        class CustomFinder:
+            @classmethod
+            def find_spec(cls, fullname, _path=None, _target=None):
+                candidate = pathlib.Path(path, *fullname.split(".")).with_suffix(".py")
+                if candidate.exists():
+                    return spec_from_file_location(fullname, candidate)
+
+            @classmethod
+            def find_distributions(self, context=DistributionFinder.Context()):
+                for dist_info in path.glob("*.dist-info"):
+                    yield PathDistribution(dist_info)
+                    name, _, _ = str(dist_info).partition("-")
+                    yield CustomDistribution(name + "_custom", dist_info)
+
+        return CustomFinder
+
+    def test_compatibility_with_old_stdlib_path_distribution(self):
+        """
+        Given a custom finder that uses Python 3.8/3.9 importlib.metadata is installed,
+        when importlib_metadata functions are called, there should be no exceptions.
+        Ref python/importlib_metadata#396.
+        """
+        self.fixtures.enter_context(fixtures.install_finder(self._meta_path_finder()))
+
+        assert list(distributions())
+        assert distribution("distinfo_pkg")
+        assert distribution("distinfo_pkg_custom")
+        assert version("distinfo_pkg") > "0"
+        assert version("distinfo_pkg_custom") > "0"
+        assert list(metadata("distinfo_pkg"))
+        assert list(metadata("distinfo_pkg_custom"))
+        assert list(entry_points(group="entries"))

--- a/tests/test_py39compat.py
+++ b/tests/test_py39compat.py
@@ -1,6 +1,6 @@
 import sys
-import unittest
 import pathlib
+import unittest
 
 from . import fixtures
 from importlib_metadata import (


### PR DESCRIPTION
This is an attempt to solve #396.

Changes:

- Added tests in 3.8/3.9 capturing expectations about custom `MetaPathFinder`s returning `PathDistribution` objects directly from stdlib.
- Added compatibility shim for `_normalized_name` during entry-point fetching
- Added compatibility shim from `EntryPoint.matches` during entry-point fetching