### PR TITLE
Clarify import vs. distribution packages in Using importlib_metadata docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -45,6 +45,13 @@ intersphinx_mapping.update(
     ),
 )
 
+intersphinx_mapping.update(
+    packaging=(
+        'https://packaging.python.org/en/latest/',
+        None,
+    ),
+)
+
 # Workaround for #316
 nitpick_ignore = [
     ('py:class', 'importlib_metadata.EntryPoints'),

--- a/docs/using.rst
+++ b/docs/using.rst
@@ -4,21 +4,23 @@
  Using :mod:`!importlib_metadata`
 =================================
 
-``importlib_metadata`` is a library that provides access to installed
-package metadata, such as its entry points or its
-top-level name.  Built in part on Python's import system, this library
+``importlib_metadata`` is a library that provides access to
+the metadata of an installed distribution package, such as its entry points
+or its top-level import package name.
+Built in part on Python's import system, this library
 intends to replace similar functionality in the `entry point
 API`_ and `metadata API`_ of ``pkg_resources``.  Along with
 :mod:`importlib.resources`,
 this package can eliminate the need to use the older and less efficient
 ``pkg_resources`` package.
 
-By "installed package" we generally mean a third-party package installed into
-Python's ``site-packages`` directory via tools such as `pip
+By "installed package", we generally mean a third-party distribution package
+installed into Python's ``site-packages`` directory via tools such as `pip
 <https://pypi.org/project/pip/>`_.  Specifically,
-it means a package with either a discoverable ``dist-info`` or ``egg-info``
+it means a distribution with either a discoverable ``dist-info`` or ``egg-info``
 directory, and metadata defined by :pep:`566` or its older specifications.
-By default, package metadata can live on the file system or in zip archives on
+By default, distribution metadata can live on the file system
+or in zip archives on
 :data:`sys.path`.  Through an extension mechanism, the metadata can live almost
 anywhere.
 
@@ -33,7 +35,8 @@ anywhere.
 Overview
 ========
 
-Let's say you wanted to get the version string for a package you've installed
+Let's say you wanted to get the version string for a
+distribution package you've installed
 using ``pip``.  We start by creating a virtual environment and installing
 something into it::
 
@@ -151,7 +154,8 @@ interface to retrieve entry points by group.
 Distribution metadata
 ---------------------
 
-Every distribution includes some metadata, which you can extract using the
+Every distribution package includes some metadata,
+which you can extract using the
 ``metadata()`` function::
 
     >>> wheel_metadata = metadata('wheel')
@@ -182,7 +186,8 @@ all the metadata in a JSON-compatible form per PEP 566::
 Distribution versions
 ---------------------
 
-The ``version()`` function is the quickest way to get a distribution's version
+The ``version()`` function is the quickest way to get a
+distribution package's version
 number, as a string::
 
     >>> version('wheel')
@@ -195,7 +200,8 @@ Distribution files
 ------------------
 
 You can also get the full set of files contained within a distribution.  The
-``files()`` function takes a distribution package name and returns all of the
+``files()`` function takes a distribution package name
+and returns all of the
 files installed by this distribution.  Each file object returned is a
 ``PackagePath``, a :class:`pathlib.PurePath` derived object with additional ``dist``,
 ``size``, and ``hash`` properties as indicated by the metadata.  For example::
@@ -240,19 +246,24 @@ distribution is not known to have the metadata present.
 Distribution requirements
 -------------------------
 
-To get the full set of requirements for a distribution, use the ``requires()``
+To get the full set of requirements for a distribution package,
+use the ``requires()``
 function::
 
     >>> requires('wheel')
     ["pytest (>=3.0.0) ; extra == 'test'", "pytest-cov ; extra == 'test'"]
 
 
-Package distributions
----------------------
+.. _package-distributions:
+.. _import-distribution-package-mapping:
 
-A convenience method to resolve the distribution or
-distributions (in the case of a namespace package) for top-level
-Python packages or modules::
+Mapping import to distribution packages
+---------------------------------------
+
+A convenience method to resolve the distribution package
+name (or names, in the case of a namespace package)
+that provide each importable top-level
+Python module or import package::
 
     >>> packages_distributions()
     {'importlib_metadata': ['importlib-metadata'], 'yaml': ['PyYAML'], 'jaraco': ['jaraco.classes', 'jaraco.functools'], ...}
@@ -264,7 +275,8 @@ Distributions
 
 While the above API is the most common and convenient usage, you can get all
 of that information from the ``Distribution`` class.  A ``Distribution`` is an
-abstract object that represents the metadata for a Python package.  You can
+abstract object that represents the metadata for
+a Python distribution package.  You can
 get the ``Distribution`` instance::
 
     >>> from importlib_metadata import distribution
@@ -291,7 +303,9 @@ for additional details.
 Distribution Discovery
 ======================
 
-By default, this package provides built-in support for discovery of metadata for file system and zip file packages. This metadata finder search defaults to ``sys.path``, but varies slightly in how it interprets those values from how other import machinery does. In particular:
+By default, this package provides built-in support for discovery of metadata
+for file system and zip file distribution packages.
+This metadata finder search defaults to ``sys.path``, but varies slightly in how it interprets those values from how other import machinery does. In particular:
 
 - ``importlib_metadata`` does not honor :class:`bytes` objects on ``sys.path``.
 - ``importlib_metadata`` will incidentally honor :py:class:`pathlib.Path` objects on ``sys.path`` even though such values will be ignored for imports.
@@ -300,15 +314,18 @@ By default, this package provides built-in support for discovery of metadata for
 Extending the search algorithm
 ==============================
 
-Because package metadata is not available through :data:`sys.path` searches, or
-package loaders directly, the metadata for a package is found through import
+Because distribution package metadata
+is not available through :data:`sys.path` searches, or
+package loaders directly,
+the metadata for a distribution is found through import
 system `finders`_.  To find a distribution package's metadata,
 ``importlib.metadata`` queries the list of :term:`meta path finders <meta path finder>` on
 :data:`sys.meta_path`.
 
 By default ``importlib_metadata`` installs a finder for distribution packages
-found on the file system.  This finder doesn't actually find any *packages*,
-but it can find the packages' metadata.
+found on the file system.
+This finder doesn't actually find any *distributions*,
+but it can find their metadata.
 
 The abstract class :py:class:`importlib.abc.MetaPathFinder` defines the
 interface expected of finders by Python's import system.

--- a/docs/using.rst
+++ b/docs/using.rst
@@ -15,11 +15,26 @@ API`_ and `metadata API`_ of ``pkg_resources``.  Along with
 this package can eliminate the need to use the older and less efficient
 ``pkg_resources`` package.
 
-By "installed package", we generally mean a third-party distribution package
-installed into Python's ``site-packages`` directory via tools such as `pip
-<https://pypi.org/project/pip/>`_.  Specifically,
-it means a distribution with either a discoverable ``dist-info`` or ``egg-info``
-directory, and metadata defined by :pep:`566` or its older specifications.
+``importlib_metadata`` operates on third-party *distribution packages*
+installed into Python's ``site-packages`` directory via tools such as
+`pip <https://pypi.org/project/pip/>`_.
+Specifically, it works with distributions with discoverable
+``dist-info`` or ``egg-info`` directories,
+and metadata defined by :pep:`566` or its older specifications.
+
+.. important::
+
+   These are *not* necessarily equivalent to or correspond 1:1 with
+   the top-level *import package* names
+   that can be imported inside Python code.
+   One *distribution package* can contain multiple *import packages*
+   (and single modules),
+   and one top-level *import package*
+   may map to multiple *distribution packages*
+   if it is a namespace package.
+   You can use :ref:`package_distributions() <package-distributions>`
+   to get a mapping between them.
+
 By default, distribution metadata can live on the file system
 or in zip archives on
 :data:`sys.path`.  Through an extension mechanism, the metadata can live almost

--- a/docs/using.rst
+++ b/docs/using.rst
@@ -5,8 +5,9 @@
 =================================
 
 ``importlib_metadata`` is a library that provides access to
-the metadata of an installed distribution package, such as its entry points
-or its top-level import package name.
+the metadata of an installed :term:`packaging:Distribution Package`,
+such as its entry points
+or its top-level :term:`packaging:Import Package` name.
 Built in part on Python's import system, this library
 intends to replace similar functionality in the `entry point
 API`_ and `metadata API`_ of ``pkg_resources``.  Along with
@@ -36,7 +37,7 @@ Overview
 ========
 
 Let's say you wanted to get the version string for a
-distribution package you've installed
+:term:`packaging:Distribution Package` you've installed
 using ``pip``.  We start by creating a virtual environment and installing
 something into it::
 
@@ -154,7 +155,7 @@ interface to retrieve entry points by group.
 Distribution metadata
 ---------------------
 
-Every distribution package includes some metadata,
+Every :term:`packaging:Distribution Package` includes some metadata,
 which you can extract using the
 ``metadata()`` function::
 
@@ -187,7 +188,7 @@ Distribution versions
 ---------------------
 
 The ``version()`` function is the quickest way to get a
-distribution package's version
+:term:`packaging:Distribution Package`'s version
 number, as a string::
 
     >>> version('wheel')
@@ -200,7 +201,7 @@ Distribution files
 ------------------
 
 You can also get the full set of files contained within a distribution.  The
-``files()`` function takes a distribution package name
+``files()`` function takes a :term:`packaging:Distribution Package` name
 and returns all of the
 files installed by this distribution.  Each file object returned is a
 ``PackagePath``, a :class:`pathlib.PurePath` derived object with additional ``dist``,
@@ -246,7 +247,7 @@ distribution is not known to have the metadata present.
 Distribution requirements
 -------------------------
 
-To get the full set of requirements for a distribution package,
+To get the full set of requirements for a :term:`packaging:Distribution Package`,
 use the ``requires()``
 function::
 
@@ -260,10 +261,10 @@ function::
 Mapping import to distribution packages
 ---------------------------------------
 
-A convenience method to resolve the distribution package
+A convenience method to resolve the :term:`packaging:Distribution Package`
 name (or names, in the case of a namespace package)
 that provide each importable top-level
-Python module or import package::
+Python module or :term:`packaging:Import Package`::
 
     >>> packages_distributions()
     {'importlib_metadata': ['importlib-metadata'], 'yaml': ['PyYAML'], 'jaraco': ['jaraco.classes', 'jaraco.functools'], ...}
@@ -276,7 +277,7 @@ Distributions
 While the above API is the most common and convenient usage, you can get all
 of that information from the ``Distribution`` class.  A ``Distribution`` is an
 abstract object that represents the metadata for
-a Python distribution package.  You can
+a Python :term:`packaging:Distribution Package`.  You can
 get the ``Distribution`` instance::
 
     >>> from importlib_metadata import distribution
@@ -304,7 +305,7 @@ Distribution Discovery
 ======================
 
 By default, this package provides built-in support for discovery of metadata
-for file system and zip file distribution packages.
+for file system and zip file :term:`packaging:Distribution Package`\s.
 This metadata finder search defaults to ``sys.path``, but varies slightly in how it interprets those values from how other import machinery does. In particular:
 
 - ``importlib_metadata`` does not honor :class:`bytes` objects on ``sys.path``.
@@ -314,7 +315,7 @@ This metadata finder search defaults to ``sys.path``, but varies slightly in how
 Extending the search algorithm
 ==============================
 
-Because distribution package metadata
+Because :term:`packaging:Distribution Package` metadata
 is not available through :data:`sys.path` searches, or
 package loaders directly,
 the metadata for a distribution is found through import

--- a/docs/using.rst
+++ b/docs/using.rst
@@ -7,7 +7,7 @@
 ``importlib_metadata`` is a library that provides access to
 the metadata of an installed :term:`packaging:Distribution Package`,
 such as its entry points
-or its top-level :term:`packaging:Import Package` name.
+or its top-level names (:term:`packaging:Import Package`s, modules, if any).
 Built in part on Python's import system, this library
 intends to replace similar functionality in the `entry point
 API`_ and `metadata API`_ of ``pkg_resources``.  Along with

--- a/docs/using.rst
+++ b/docs/using.rst
@@ -20,7 +20,7 @@ installed into Python's ``site-packages`` directory via tools such as
 `pip <https://pypi.org/project/pip/>`_.
 Specifically, it works with distributions with discoverable
 ``dist-info`` or ``egg-info`` directories,
-and metadata defined by :pep:`566` or its older specifications.
+and metadata defined by the :ref:`packaging:core-metadata`.
 
 .. important::
 
@@ -312,8 +312,8 @@ instance::
     >>> dist.metadata['License']
     'MIT'
 
-The full set of available metadata is not described here.  See :pep:`566`
-for additional details.
+The full set of available metadata is not described here.
+See the :ref:`packaging:core-metadata` for additional details.
 
 
 Distribution Discovery


### PR DESCRIPTION
As [requested on the Python Discourse](https://discuss.python.org/t/dynamic-versions-in-editable-installations/15220/46), addresses #398 (import vs. distribution packages not being clear) by:

* Using "distribution package"/"import package" on first use in each section
* Disambiguating the unqualified term "package" (preferring "distribution" and "import package", respectively) [^unsure]
* Linking the terms to the PyPA glossary once on first use in each section they are used in [^termlinks]
* Adding an admonition at the top explicitly calling out the differences and referring the reader to the `package_distributions()` function to map between them

Additionally, this incorporates a couple required/directly related changes:

* Fix a few grammar/textual problems on already-modified lines
* Add an intersphinx mapping to packaging.python.org to properly reference the terms and specs there [^intersphinx]
* Also uses such to reference the canonical, self-contained, up to date [Core metadata spec]() rather than an old, incremental, historical PEP. [^coremetadata]

Fix #398

Reviewer notes:

[^unsure]: I'm not 100% sure myself about the disambiguations in the highly technical ``Extending the search algorithm`` Explanation—please check to confirm I've gotten them correct.

[^termlinks]: So readers don't have to go hunting through other sections to find them, if they do so at all

[^intersphinx]:  If this needs to go in your skeleton, I can submit a PR there, drop that commit here and rebase accordingly once that is updated. Also, I was confused by some were written as dict literals, and some were added with `dict.update`, with no obvious or stated reason—I though it might have to do with the former being from your skeleton and the latter being local, but your skeleton looks identical, so I'm not sure what's going on or where packaging.python.org. Please advise and I'll be happy to add it in whichever manner is appropriate.

[^coremetadata]: If required, I can pull this out to a separate followup PR, though it is small enough I just added it here to avoid extra overhead on both our parts.