### PR TITLE
Mention API ref & migration guide in importlib_metadata See Also

### DIFF
--- a/docs/using.rst
+++ b/docs/using.rst
@@ -28,6 +28,12 @@ anywhere.
    https://importlib-metadata.readthedocs.io/
       The documentation for ``importlib_metadata``, which supplies a
       backport of ``importlib.metadata``.
+      This includes an `API reference
+      <https://importlib-metadata.readthedocs.io/en/latest/api.html>`__
+      for this module's classes and functions,
+      as well as a `migration guide
+      <https://importlib-metadata.readthedocs.io/en/latest/migration.html>`__
+      for existing users of ``pkg_resources``.
 
 
 Overview


### PR DESCRIPTION
Per #400 and as As [discussed on the Python Discourse](https://discuss.python.org/t/dynamic-versions-in-editable-installations/15220/44), this clarifies the  [Using importlib_metadata documentation](https://importlib-metadata.readthedocs.io/en/latest/using.html) (and thus its [CPython equivalent](https://docs.python.org/3.12/library/importlib.metadata.html)) that the API documentation (and migration guide) for the latest version of ``importlib.metadata` can be found on the ``importlib_metadata`` docs site.

Fix #400 