### PR TITLE
Simplify compatibility wrappers

### DIFF
--- a/importlib_metadata/__init__.py
+++ b/importlib_metadata/__init__.py
@@ -382,8 +382,7 @@ class EntryPoints(DeprecatedList):
         Select entry points from self that match the
         given parameters (typically group and/or name).
         """
-        candidates = (_py39compat.ep_matches(ep, **params) for ep in self)
-        return EntryPoints(ep for ep, predicate in candidates if predicate)
+        return EntryPoints(ep for ep in self if _py39compat.ep_matches(ep, **params))
 
     @property
     def names(self):

--- a/importlib_metadata/_py39compat.py
+++ b/importlib_metadata/_py39compat.py
@@ -1,7 +1,7 @@
 """
 Compatibility layer with Python 3.8/3.9
 """
-from typing import TYPE_CHECKING, Any, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Optional
 
 if TYPE_CHECKING:  # pragma: no cover
     # Prevent circular imports on runtime.
@@ -22,27 +22,14 @@ def normalized_name(dist: Distribution) -> Optional[str]:
         return Prepared.normalize(getattr(dist, "name", None) or dist.metadata['Name'])
 
 
-def ep_matches(ep: EntryPoint, **params) -> Tuple[EntryPoint, bool]:
+def ep_matches(ep: EntryPoint, **params) -> bool:
     """
     Workaround for ``EntryPoint`` objects without the ``matches`` method.
-    For the sake of convenience, a tuple is returned containing not only the
-    boolean value corresponding to the predicate evalutation, but also a compatible
-    ``EntryPoint`` object that can be safely used at a later stage.
-
-    For example, the following sequences of expressions should be compatible:
-
-        # Sequence 1: using the compatibility layer
-        candidates = (_py39compat.ep_matches(ep, **params) for ep in entry_points)
-        [ep for ep, predicate in candidates if predicate]
-
-        # Sequence 2: using Python 3.9+
-        [ep for ep in entry_points if ep.matches(**params)]
     """
     try:
-        return ep, ep.matches(**params)
+        return ep.matches(**params)
     except AttributeError:
         from . import EntryPoint  # -> delay to prevent circular imports.
 
         # Reconstruct the EntryPoint object to make sure it is compatible.
-        _ep = EntryPoint(ep.name, ep.value, ep.group)
-        return _ep, _ep.matches(**params)
+        return EntryPoint(ep.name, ep.value, ep.group).matches(**params)


### PR DESCRIPTION
These changes limit the complexity of the compatibility wrappers and make it easier to reason about how to remove them when appropriate.