### PR TITLE
Instrument `SimplePath` protocol with generic support

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,8 @@
+v5.1.0
+======
+
+* #415: Instrument ``SimplePath`` with generic support.
+
 v5.0.0
 ======
 

--- a/importlib_metadata/_meta.py
+++ b/importlib_metadata/_meta.py
@@ -30,18 +30,19 @@ class PackageMetadata(Protocol):
         """
 
 
-class SimplePath(Protocol):
+class SimplePath(Protocol[_T]):
     """
     A minimal subset of pathlib.Path required by PathDistribution.
     """
 
-    def joinpath(self) -> 'SimplePath':
+    def joinpath(self) -> _T:
         ...  # pragma: no cover
 
-    def __truediv__(self) -> 'SimplePath':
+    def __truediv__(self, other: Union[str, _T]) -> _T:
         ...  # pragma: no cover
 
-    def parent(self) -> 'SimplePath':
+    @property
+    def parent(self) -> _T:
         ...  # pragma: no cover
 
     def read_text(self) -> str:


### PR DESCRIPTION
This makes `pathlib.Path`s and `zipfile.Path`s assignable to the protocol.