### PR TITLE
Raise KeyError when requesting a metadata value that doesn't exist

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,18 @@
+v6.0.0
+======
+
+* #371: When a key is missing from metadata, raise a ``KeyError``
+  instead of returning ``None``, matching the usual expectation for
+  mapping objects and also the protocol definition.
+
+  Projects should update to expect the ``KeyError`` or wrap the call
+  to replace a ``KeyError`` with a ``None`` return, e.g.::
+
+      try:
+          value = metadata(pkg)['Name']
+      except KeyError:
+          value = None
+
 v5.1.0
 ======
 

--- a/importlib_metadata/_adapters.py
+++ b/importlib_metadata/_adapters.py
@@ -39,6 +39,20 @@ class Message(email.message.Message):
     def __iter__(self):
         return super().__iter__()
 
+    def __getitem__(self, item):
+        """
+        Prefer dict-like behavior for __getitem__ when keys are missing.
+        >>> msg = Message(email.message.Message())
+        >>> msg['thing']
+        Traceback (most recent call last):
+        ...
+        KeyError: 'thing'
+        """
+        res = super().__getitem__(item)
+        if res is None:
+            raise KeyError(item)
+        return res
+
     def _repair_headers(self):
         def redent(value):
             "Correct for RFC822 indentation"

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -141,6 +141,15 @@ class APITests(
         resolved = version('importlib-metadata')
         assert re.match(self.version_pattern, resolved)
 
+    @__import__('pytest').mark.xfail(reason="not implemented #371")
+    def test_missing_key(self):
+        """
+        Attempting to request missing metadata raises KeyError.
+        """
+        md = metadata('distinfo-pkg')
+        with self.assertRaises(KeyError):
+            md['does-not-exist']
+
     @staticmethod
     def _test_files(files):
         root = files[0].root

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -141,7 +141,6 @@ class APITests(
         resolved = version('importlib-metadata')
         assert re.match(self.version_pattern, resolved)
 
-    @__import__('pytest').mark.xfail(reason="not implemented #371")
     def test_missing_key(self):
         """
         Attempting to request missing metadata raises KeyError.


### PR DESCRIPTION
- Add test capturing that a missing key raises a KeyError. Ref #371.
- When requesting an item from metadata, if it's not present, raise a KeyError. Fixes #371.
- Update changelog.
