### PR TITLE
Declare Distribution as an abstract class.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,15 @@
+v6.0.0
+======
+
+* #419: Declared ``Distribution`` as an abstract class, enforcing
+  definition of abstract methods in instantiated subclasses. It's no
+  longer possible to instantiate a ``Distribution`` or any subclasses
+  unless they define the abstract methods.
+
+  Please comment in the issue if this change breaks any projects.
+  This change will likely be rolled back if it causes significant
+  disruption.
+
 v5.2.0
 ======
 

--- a/importlib_metadata/__init__.py
+++ b/importlib_metadata/__init__.py
@@ -346,7 +346,7 @@ class FileHash:
         return f'<FileHash mode: {self.mode} value: {self.value}>'
 
 
-class Distribution:
+class Distribution(metaclass=abc.ABCMeta):
     """A Python distribution package."""
 
     @abc.abstractmethod

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -43,6 +43,11 @@ class BasicTests(fixtures.DistInfoPkg, unittest.TestCase):
 
         assert "metadata" in str(ctx.exception)
 
+    def test_abc_enforced(self):
+        with self.assertRaises(AssertionError):  # xfail
+            with self.assertRaises(TypeError):
+                type('DistributionSubclass', (Distribution,), {})()
+
     @fixtures.parameterize(
         dict(name=None),
         dict(name=''),

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -44,9 +44,8 @@ class BasicTests(fixtures.DistInfoPkg, unittest.TestCase):
         assert "metadata" in str(ctx.exception)
 
     def test_abc_enforced(self):
-        with self.assertRaises(AssertionError):  # xfail
-            with self.assertRaises(TypeError):
-                type('DistributionSubclass', (Distribution,), {})()
+        with self.assertRaises(TypeError):
+            type('DistributionSubclass', (Distribution,), {})()
 
     @fixtures.parameterize(
         dict(name=None),


### PR DESCRIPTION
- Add xfail test capturing desired expectation.
- Add ABCMeta to Distribution. Fixes #419.
- Update changelog. Ref #419.
