### PR TITLE
Ensure that requirements follow PEP508

### DIFF
--- a/importlib_metadata/__init__.py
+++ b/importlib_metadata/__init__.py
@@ -522,16 +522,16 @@ class Distribution(metaclass=abc.ABCMeta):
         latter. See _test_deps_from_requires_text for an example.
         """
 
-        def make_condition(name):
-            return name and f'extra == "{name}"'
-
         def quoted_marker(section):
             section = section or ''
             extra, sep, markers = section.partition(':')
-            if extra and markers:
-                markers = f'({markers})'
-            conditions = list(filter(None, [markers, make_condition(extra)]))
-            return '; ' + ' and '.join(conditions) if conditions else ''
+            extras_txt = ''
+            if extra:
+                extras_txt = '[' + extra + ']'
+            markers_txt = ''
+            if markers:
+                markers_txt = '; ' + markers
+            return extras_txt + markers_txt
 
         def url_req_space(req):
             """
@@ -539,7 +539,7 @@ class Distribution(metaclass=abc.ABCMeta):
             Ref python/importlib_metadata#357.
             """
             # '@' is uniquely indicative of a url_req.
-            return ' ' * ('@' in req)
+            return ' ' if '@' in req else ''
 
         for section in sections:
             space = url_req_space(section.value)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -214,7 +214,7 @@ class APITests(
             dep4
             dep6@ git+https://example.com/python/dep.git@v1.0.0
 
-            [extra2:python_version < "3"]
+            [extra2:python_version < "3" and os_name=="a"]
             dep5
             """
         )
@@ -223,9 +223,9 @@ class APITests(
             'dep1',
             'dep2',
             'dep3; python_version < "3"',
-            'dep4; extra == "extra1"',
-            'dep5; (python_version < "3") and extra == "extra2"',
-            'dep6@ git+https://example.com/python/dep.git@v1.0.0 ; extra == "extra1"',
+            'dep4[extra1]',
+            'dep5[extra2]; python_version < "3" and os_name=="a"',
+            'dep6@ git+https://example.com/python/dep.git@v1.0.0 [extra1]',
         ]
         # It's important that the environment marker expression be
         # wrapped in parentheses to avoid the following 'and' binding more


### PR DESCRIPTION
It looks to me that the requirements produced when reading egg-info ``requires.txt`` is trying to be converted into PEP508 compatible form, but that the implementation doesn't follow the spec with regards to extras. This PR updates the implementation to better reflect the PEP, and updates the tests accordingly.

One thing I am not clear on however:

I can't see a limitation on the ``requires.txt`` format, and believe that the following could be a valid file:

```
dep1
dep2

[extra1]
dep3

[extra2]
dep3
```

The result, I assume should be 3 lines of requirements (with the latter line being ``dep3[extra1,extra2]``), however the existing function does not group by the dependency name, and therefore will result in 4 requirements lines. The logic for doing this grouping could get hairy for mutually exclusive markers though, and it is not clear whether this should be addressed or not (I don't have enough overview of the current state of PEPs in this area).