### PR TITLE
Add missing modules to packages_distributions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,10 @@
+v6.1.0
+======
+
+* #428: ``packages_distributions`` now honors packages and modules
+  with Python modules that not ``.py`` sources (e.g. ``.pyc``,
+  ``.so``).
+
 v6.0.1
 ======
 

--- a/importlib_metadata/__init__.py
+++ b/importlib_metadata/__init__.py
@@ -899,7 +899,7 @@ def _top_level_declared(dist):
 
 def _top_level_inferred(dist):
     opt_names = {
-        inspect.getmodulename(f) if len(f.parts) == 1 else f.parts[0]
+        f.parts[0] if len(f.parts) > 1 else inspect.getmodulename(f)
         for f in always_iterable(dist.files)
     }
     return filter(None, opt_names)

--- a/importlib_metadata/__init__.py
+++ b/importlib_metadata/__init__.py
@@ -13,6 +13,7 @@ import functools
 import itertools
 import posixpath
 import collections
+import inspect
 
 from . import _adapters, _meta, _py39compat
 from ._collections import FreezableDefaultDict, Pair
@@ -897,8 +898,11 @@ def _top_level_declared(dist):
 
 
 def _top_level_inferred(dist):
-    return {
-        f.parts[0] if len(f.parts) > 1 else f.with_suffix('').name
-        for f in always_iterable(dist.files)
-        if f.suffix == ".py"
-    }
+    return filter(
+        None,
+        {
+            # this logic relies on the assumption that dist.files only contains files (not directories)
+            inspect.getmodulename(f) if len(f.parts) == 1 else f.parts[0]
+            for f in always_iterable(dist.files)
+        },
+    )

--- a/importlib_metadata/__init__.py
+++ b/importlib_metadata/__init__.py
@@ -898,10 +898,8 @@ def _top_level_declared(dist):
 
 
 def _top_level_inferred(dist):
-    return filter(
-        None,
-        {
-            inspect.getmodulename(f) if len(f.parts) == 1 else f.parts[0]
-            for f in always_iterable(dist.files)
-        },
-    )
+    opt_names = {
+        inspect.getmodulename(f) if len(f.parts) == 1 else f.parts[0]
+        for f in always_iterable(dist.files)
+    }
+    return filter(None, opt_names)

--- a/importlib_metadata/__init__.py
+++ b/importlib_metadata/__init__.py
@@ -901,7 +901,6 @@ def _top_level_inferred(dist):
     return filter(
         None,
         {
-            # this logic relies on the assumption that dist.files only contains files (not directories)
             inspect.getmodulename(f) if len(f.parts) == 1 else f.parts[0]
             for f in always_iterable(dist.files)
         },

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -322,3 +322,34 @@ class PackagesDistributionsTest(
             prefix=self.site_dir,
         )
         packages_distributions()
+
+    def test_packages_distributions_all_module_types(self):
+        """
+        Test top-level modules detected on a package without 'top-level.txt'.
+        """
+        suffixes = importlib.machinery.all_suffixes()
+        fixtures.build_files(
+            {
+                'all_distributions-1.0.0.dist-info': {
+                    'METADATA': """
+                        Name: all_distributions
+                        Version: 1.0.0
+                    """,
+                    'RECORD': ''.join(
+                        f'{i}-top-level{suffix},,\n'
+                        f'{i}-in-namespace/mod{suffix},,\n'
+                        f'{i}-in-package/__init__.py,,\n'
+                        f'{i}-in-package/mod{suffix},,\n'
+                        for i, suffix in enumerate(suffixes)
+                    ),
+                },
+            },
+            prefix=self.site_dir,
+        )
+
+        distributions = packages_distributions()
+
+        for i in range(len(suffixes)):
+            assert distributions[f'{i}-top-level'] == ['all_distributions']
+            assert distributions[f'{i}-in-namespace'] == ['all_distributions']
+            assert distributions[f'{i}-in-package'] == ['all_distributions']


### PR DESCRIPTION
This now considers:
  - Modules that don't have the `.py` prefix (eg. native modules, `.pyc`-only modules)
  - Namespace packages without any `.py` files inside

Which I think should be all possible modules, right?

Fix #428