### PR TITLE
Fix formatting in test_api

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -32,7 +32,6 @@ class APITests(
     fixtures.EggInfoFile,
     unittest.TestCase,
 ):
-
     version_pattern = r'\d+\.\d+(\.\d)?'
 
     def test_retrieves_version_of_self(self):


### PR DESCRIPTION
Tests are failing on #432 because of this formatting issue, which is unrelated. I assume something in the formatter changed, causing the current code to be outdated, which is undesirable in a formatter :upside_down_face: