### PR TITLE
Temporarily disable 3.12 CI due to incompatibility in pyfakefs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,7 +41,8 @@ jobs:
         python:
         - "3.7"
         - "3.11"
-        - "3.12"
+        # 3.12 is temporarily disabled due to https://github.com/pytest-dev/pyfakefs/issues/770
+        # - "3.12"
         # Workaround for actions/setup-python#508
         dev:
         - -dev


### PR DESCRIPTION
3.12 is currently broken due to https://github.com/pytest-dev/pyfakefs/issues/770