### PR TITLE
Fix .files and inferred packages_distributions for .egg-info packages

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,9 @@
+v6.3.0
+======
+
+* #115: Support ``installed-files.txt`` for ``Distribution.files``
+  when present.
+
 v6.2.1
 ======
 

--- a/importlib_metadata/__init__.py
+++ b/importlib_metadata/__init__.py
@@ -475,17 +475,18 @@ class Distribution(metaclass=abc.ABCMeta):
 
         @pass_none
         def make_files(lines):
-            return list(
-                filter(
-                    lambda package_path: package_path.locate().exists(),
-                    starmap(make_file, csv.reader(lines)),
-                )
-            )
+            return starmap(make_file, csv.reader(lines))
 
-        return make_files(
-            self._read_files_distinfo()
-            or self._read_files_egginfo_installed()
-            or self._read_files_egginfo_sources()
+        @pass_none
+        def skip_missing_files(package_paths):
+            return list(filter(lambda path: path.locate().exists(), package_paths))
+
+        return skip_missing_files(
+            make_files(
+                self._read_files_distinfo()
+                or self._read_files_egginfo_installed()
+                or self._read_files_egginfo_sources()
+            )
         )
 
     def _read_files_distinfo(self):

--- a/importlib_metadata/__init__.py
+++ b/importlib_metadata/__init__.py
@@ -478,7 +478,7 @@ class Distribution(metaclass=abc.ABCMeta):
             return list(
                 filter(
                     lambda package_path: package_path.locate().exists(),
-                    list(starmap(make_file, csv.reader(lines))),
+                    starmap(make_file, csv.reader(lines)),
                 )
             )
 

--- a/importlib_metadata/__init__.py
+++ b/importlib_metadata/__init__.py
@@ -512,7 +512,16 @@ class Distribution(metaclass=abc.ABCMeta):
         # But this subdir is only available in the PathDistribution's self._path
         # which is not easily accessible from this base class...
         subdir = getattr(self, '_path', None)
-        return text and subdir and [f'"{subdir}/{line}"' for line in text.splitlines()]
+        try:
+            if text and subdir:
+                ret = [
+                    str((subdir / line).resolve().relative_to(self.locate_file('')))
+                    for line in text.splitlines()
+                ]
+                return map('"{}"'.format, ret)
+        except Exception:
+            pass
+        return None
 
     def _read_files_egginfo_sources(self):
         """

--- a/importlib_metadata/__init__.py
+++ b/importlib_metadata/__init__.py
@@ -474,7 +474,12 @@ class Distribution(metaclass=abc.ABCMeta):
 
         @pass_none
         def make_files(lines):
-            return list(starmap(make_file, csv.reader(lines)))
+            return list(
+                filter(
+                    lambda package_path: package_path.locate().exists(),
+                    list(starmap(make_file, csv.reader(lines))),
+                )
+            )
 
         return make_files(
             self._read_files_distinfo()

--- a/importlib_metadata/__init__.py
+++ b/importlib_metadata/__init__.py
@@ -12,6 +12,7 @@ import warnings
 import functools
 import itertools
 import posixpath
+import contextlib
 import collections
 import inspect
 
@@ -513,16 +514,14 @@ class Distribution(metaclass=abc.ABCMeta):
         # But this subdir is only available in the PathDistribution's self._path
         # which is not easily accessible from this base class...
         subdir = getattr(self, '_path', None)
-        try:
-            if text and subdir:
-                ret = [
-                    str((subdir / line).resolve().relative_to(self.locate_file('')))
-                    for line in text.splitlines()
-                ]
-                return map('"{}"'.format, ret)
-        except Exception:
-            pass
-        return None
+        if not text or not subdir:
+            return
+        with contextlib.suppress(Exception):
+            ret = [
+                str((subdir / line).resolve().relative_to(self.locate_file('')))
+                for line in text.splitlines()
+            ]
+            return map('"{}"'.format, ret)
 
     def _read_files_egginfo_sources(self):
         """

--- a/importlib_metadata/__init__.py
+++ b/importlib_metadata/__init__.py
@@ -498,10 +498,10 @@ class Distribution(metaclass=abc.ABCMeta):
 
     def _read_files_egginfo_installed(self):
         """
-        installed-files.txt might contain literal commas, so wrap
-        each line in quotes. Also, the entries in installed-files.txt
-        are relative to the .egg-info/ subdir (not relative to the
-        parent site-packages directory that make_file() expects).
+        Read installed-files.txt and return lines in a similar
+        CSV-parsable format as RECORD: each file must be placed
+        relative to the site-packages directory, and must also be
+        quoted (since file names can contain literal commas).
 
         This file is written when the package is installed by pip,
         but it might not be written for other installation methods.
@@ -526,8 +526,9 @@ class Distribution(metaclass=abc.ABCMeta):
 
     def _read_files_egginfo_sources(self):
         """
-        SOURCES.txt might contain literal commas, so wrap each line
-        in quotes.
+        Read SOURCES.txt and return lines in a similar CSV-parsable
+        format as RECORD: each file name must be quoted (since it
+        might contain literal commas).
 
         Note that SOURCES.txt is not a reliable source for what
         files are installed by a package. This file is generated

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -243,6 +243,32 @@ class EggInfoPkgPipInstalledNoModules(OnSysPath, SiteDir):
         build_files(EggInfoPkgPipInstalledNoModules.files, prefix=self.site_dir)
 
 
+class EggInfoPkgSourcesFallback(OnSysPath, SiteDir):
+    files: FilesDef = {
+        "starved_egg_pkg.egg-info": {
+            "PKG-INFO": "Name: starved_egg-pkg",
+            # SOURCES.txt is made from the source archive, and contains files
+            # (setup.py) that are not present after installation.
+            "SOURCES.txt": """
+                starved_egg_pkg.py
+                setup.py
+                starved_egg_pkg.egg-info/PKG-INFO
+                starved_egg_pkg.egg-info/SOURCES.txt
+            """,
+            # missing installed-files.txt (i.e. not installed by pip)
+            # missing top_level.txt
+        },
+        "starved_egg_pkg.py": """
+            def main():
+                print("hello world")
+            """,
+    }
+
+    def setUp(self):
+        super().setUp()
+        build_files(EggInfoPkgSourcesFallback.files, prefix=self.site_dir)
+
+
 class EggInfoFile(OnSysPath, SiteDir):
     files: FilesDef = {
         "egginfo_file.egg-info": """

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -250,15 +250,15 @@ class EggInfoPkgPipInstalledNoToplevel(OnSysPath, SiteDir):
 
 class EggInfoPkgPipInstalledNoModules(OnSysPath, SiteDir):
     files: FilesDef = {
-        "empty_egg_pkg.egg-info": {
-            "PKG-INFO": "Name: empty_egg-pkg",
+        "egg_with_no_modules_pkg.egg-info": {
+            "PKG-INFO": "Name: egg_with_no_modules-pkg",
             # SOURCES.txt is made from the source archive, and contains files
             # (setup.py) that are not present after installation.
             "SOURCES.txt": """
                 setup.py
-                empty_egg_pkg.egg-info/PKG-INFO
-                empty_egg_pkg.egg-info/SOURCES.txt
-                empty_egg_pkg.egg-info/top_level.txt
+                egg_with_no_modules_pkg.egg-info/PKG-INFO
+                egg_with_no_modules_pkg.egg-info/SOURCES.txt
+                egg_with_no_modules_pkg.egg-info/top_level.txt
             """,
             # installed-files.txt is written by pip, and is a strictly more
             # accurate source than SOURCES.txt as to the installed contents of

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -351,7 +351,6 @@ def build_files(file_defs, prefix=pathlib.Path()):
             full_name.mkdir()
             build_files(contents, prefix=full_name)
         else:
-            full_name.parent.mkdir(parents=True, exist_ok=True)
             if isinstance(contents, bytes):
                 with full_name.open('wb') as f:
                     f.write(contents)

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -83,8 +83,10 @@ class OnSysPath(Fixtures):
 
 
 # Except for python/mypy#731, prefer to define
-# FilesDef = Dict[str, Union['FilesDef', str]]
-FilesDef = Dict[str, Union[Dict[str, Union[Dict[str, str], str]], str]]
+# FilesDef = Dict[str, Union['FilesDef', str, bytes]]
+FilesDef = Dict[
+    str, Union[Dict[str, Union[Dict[str, Union[str, bytes]], str, bytes]], str, bytes]
+]
 
 
 class DistInfoPkg(OnSysPath, SiteDir):

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -243,7 +243,7 @@ class EggInfoPkgPipInstalledNoToplevel(OnSysPath, SiteDir):
         "egg_with_module.py": """
             def main():
                 print("hello world")
-            """
+            """,
     }
 
     def setUp(self):

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -213,6 +213,41 @@ class EggInfoPkg(OnSysPath, SiteDir):
         build_files(EggInfoPkg.files, prefix=self.site_dir)
 
 
+class EggInfoPkgPipInstalledNoToplevel(OnSysPath, SiteDir):
+    files: FilesDef = {
+        "egg_with_module_pkg.egg-info": {
+            "PKG-INFO": "Name: egg_with_module-pkg",
+            # SOURCES.txt is made from the source archive, and contains files
+            # (setup.py) that are not present after installation.
+            "SOURCES.txt": """
+                egg_with_module.py
+                setup.py
+                egg_with_module_pkg.egg-info/PKG-INFO
+                egg_with_module_pkg.egg-info/SOURCES.txt
+                egg_with_module_pkg.egg-info/top_level.txt
+            """,
+            # installed-files.txt is written by pip, and is a strictly more
+            # accurate source than SOURCES.txt as to the installed contents of
+            # the package.
+            "installed-files.txt": """
+                ../egg_with_module.py
+                PKG-INFO
+                SOURCES.txt
+                top_level.txt
+            """,
+            # missing top_level.txt (to trigger fallback to installed-files.txt)
+        },
+        "egg_with_module.py": """
+            def main():
+                print("hello world")
+            """
+    }
+
+    def setUp(self):
+        super().setUp()
+        build_files(EggInfoPkgPipInstalledNoToplevel.files, prefix=self.site_dir)
+
+
 class EggInfoPkgPipInstalledNoModules(OnSysPath, SiteDir):
     files: FilesDef = {
         "empty_egg_pkg.egg-info": {

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -351,6 +351,7 @@ def build_files(file_defs, prefix=pathlib.Path()):
             full_name.mkdir()
             build_files(contents, prefix=full_name)
         else:
+            full_name.parent.mkdir(parents=True, exist_ok=True)
             if isinstance(contents, bytes):
                 with full_name.open('wb') as f:
                     f.write(contents)

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -213,6 +213,36 @@ class EggInfoPkg(OnSysPath, SiteDir):
         build_files(EggInfoPkg.files, prefix=self.site_dir)
 
 
+class EggInfoPkgPipInstalledNoModules(OnSysPath, SiteDir):
+    files: FilesDef = {
+        "empty_egg_pkg.egg-info": {
+            "PKG-INFO": "Name: empty_egg-pkg",
+            # SOURCES.txt is made from the source archive, and contains files
+            # (setup.py) that are not present after installation.
+            "SOURCES.txt": """
+                setup.py
+                empty_egg_pkg.egg-info/PKG-INFO
+                empty_egg_pkg.egg-info/SOURCES.txt
+                empty_egg_pkg.egg-info/top_level.txt
+            """,
+            # installed-files.txt is written by pip, and is a strictly more
+            # accurate source than SOURCES.txt as to the installed contents of
+            # the package.
+            "installed-files.txt": """
+                PKG-INFO
+                SOURCES.txt
+                top_level.txt
+            """,
+            # top_level.txt correctly reflects that no modules are installed
+            "top_level.txt": b"\n",
+        },
+    }
+
+    def setUp(self):
+        super().setUp()
+        build_files(EggInfoPkgPipInstalledNoModules.files, prefix=self.site_dir)
+
+
 class EggInfoFile(OnSysPath, SiteDir):
     files: FilesDef = {
         "egginfo_file.egg-info": """

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -280,20 +280,20 @@ class EggInfoPkgPipInstalledNoModules(OnSysPath, SiteDir):
 
 class EggInfoPkgSourcesFallback(OnSysPath, SiteDir):
     files: FilesDef = {
-        "starved_egg_pkg.egg-info": {
-            "PKG-INFO": "Name: starved_egg-pkg",
+        "sources_fallback_pkg.egg-info": {
+            "PKG-INFO": "Name: sources_fallback-pkg",
             # SOURCES.txt is made from the source archive, and contains files
             # (setup.py) that are not present after installation.
             "SOURCES.txt": """
-                starved_egg_pkg.py
+                sources_fallback.py
                 setup.py
-                starved_egg_pkg.egg-info/PKG-INFO
-                starved_egg_pkg.egg-info/SOURCES.txt
+                sources_fallback_pkg.egg-info/PKG-INFO
+                sources_fallback_pkg.egg-info/SOURCES.txt
             """,
-            # missing installed-files.txt (i.e. not installed by pip)
-            # missing top_level.txt
+            # missing installed-files.txt (i.e. not installed by pip) and
+            # missing top_level.txt (to trigger fallback to SOURCES.txt)
         },
-        "starved_egg_pkg.py": """
+        "sources_fallback.py": """
             def main():
                 print("hello world")
             """,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -67,7 +67,7 @@ class APITests(
     def test_for_top_level(self):
         tests = [
             ('egginfo-pkg', 'mod'),
-            ('empty_egg-pkg', ''),
+            ('egg_with_no_modules-pkg', ''),
         ]
         for pkg_name, expect_content in tests:
             with self.subTest(pkg_name):
@@ -79,7 +79,7 @@ class APITests(
     def test_read_text(self):
         tests = [
             ('egginfo-pkg', 'mod\n'),
-            ('empty_egg-pkg', '\n'),
+            ('egg_with_no_modules-pkg', '\n'),
         ]
         for pkg_name, expect_content in tests:
             with self.subTest(pkg_name):
@@ -187,7 +187,7 @@ class APITests(
     def test_files_egg_info(self):
         self._test_files(files('egginfo-pkg'))
         self._test_files(files('egg_with_module-pkg'))
-        self._test_files(files('empty_egg-pkg'))
+        self._test_files(files('egg_with_no_modules-pkg'))
         self._test_files(files('sources_fallback-pkg'))
 
     def test_version_egg_info_file(self):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -27,6 +27,7 @@ def suppress_known_deprecation():
 
 class APITests(
     fixtures.EggInfoPkg,
+    fixtures.EggInfoPkgPipInstalledNoToplevel,
     fixtures.EggInfoPkgPipInstalledNoModules,
     fixtures.EggInfoPkgSourcesFallback,
     fixtures.DistInfoPkg,
@@ -185,6 +186,7 @@ class APITests(
 
     def test_files_egg_info(self):
         self._test_files(files('egginfo-pkg'))
+        self._test_files(files('egg_with_module-pkg'))
         self._test_files(files('empty_egg-pkg'))
         self._test_files(files('starved_egg-pkg'))
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -188,7 +188,7 @@ class APITests(
         self._test_files(files('egginfo-pkg'))
         self._test_files(files('egg_with_module-pkg'))
         self._test_files(files('empty_egg-pkg'))
-        self._test_files(files('starved_egg-pkg'))
+        self._test_files(files('sources_fallback-pkg'))
 
     def test_version_egg_info_file(self):
         self.assertEqual(version('egginfo-file'), '0.1')

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -28,6 +28,7 @@ def suppress_known_deprecation():
 class APITests(
     fixtures.EggInfoPkg,
     fixtures.EggInfoPkgPipInstalledNoModules,
+    fixtures.EggInfoPkgSourcesFallback,
     fixtures.DistInfoPkg,
     fixtures.DistInfoPkgWithDot,
     fixtures.EggInfoFile,
@@ -185,6 +186,7 @@ class APITests(
     def test_files_egg_info(self):
         self._test_files(files('egginfo-pkg'))
         self._test_files(files('empty_egg-pkg'))
+        self._test_files(files('starved_egg-pkg'))
 
     def test_version_egg_info_file(self):
         self.assertEqual(version('egginfo-file'), '0.1')

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -27,12 +27,12 @@ def suppress_known_deprecation():
 
 class APITests(
     fixtures.EggInfoPkg,
+    fixtures.EggInfoPkgPipInstalledNoModules,
     fixtures.DistInfoPkg,
     fixtures.DistInfoPkgWithDot,
     fixtures.EggInfoFile,
     unittest.TestCase,
 ):
-
     version_pattern = r'\d+\.\d+(\.\d)?'
 
     def test_retrieves_version_of_self(self):
@@ -63,15 +63,28 @@ class APITests(
                     distribution(prefix)
 
     def test_for_top_level(self):
-        self.assertEqual(
-            distribution('egginfo-pkg').read_text('top_level.txt').strip(), 'mod'
-        )
+        tests = [
+            ('egginfo-pkg', 'mod'),
+            ('empty_egg-pkg', ''),
+        ]
+        for pkg_name, expect_content in tests:
+            with self.subTest(pkg_name):
+                self.assertEqual(
+                    distribution(pkg_name).read_text('top_level.txt').strip(),
+                    expect_content,
+                )
 
     def test_read_text(self):
-        top_level = [
-            path for path in files('egginfo-pkg') if path.name == 'top_level.txt'
-        ][0]
-        self.assertEqual(top_level.read_text(), 'mod\n')
+        tests = [
+            ('egginfo-pkg', 'mod\n'),
+            ('empty_egg-pkg', '\n'),
+        ]
+        for pkg_name, expect_content in tests:
+            with self.subTest(pkg_name):
+                top_level = [
+                    path for path in files(pkg_name) if path.name == 'top_level.txt'
+                ][0]
+                self.assertEqual(top_level.read_text(), expect_content)
 
     def test_entry_points(self):
         eps = entry_points()
@@ -171,6 +184,7 @@ class APITests(
 
     def test_files_egg_info(self):
         self._test_files(files('egginfo-pkg'))
+        self._test_files(files('empty_egg-pkg'))
 
     def test_version_egg_info_file(self):
         self.assertEqual(version('egginfo-file'), '0.1')

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -342,10 +342,10 @@ class PackagesDistributionsTest(
         filenames = list(
             itertools.chain.from_iterable(
                 [
-                    f'top_level_{i}{suffix}',
-                    f'in_namespace_{i}/mod{suffix}',
-                    f'in_package_{i}/__init__.py',
-                    f'in_package_{i}/mod{suffix}',
+                    f'{i}-top-level{suffix}',
+                    f'{i}-in-namespace/mod{suffix}',
+                    f'{i}-in-package/__init__.py',
+                    f'{i}-in-package/mod{suffix}',
                 ]
                 for i, suffix in enumerate(suffixes)
             )
@@ -367,14 +367,9 @@ class PackagesDistributionsTest(
         distributions = packages_distributions()
 
         for i in range(len(suffixes)):
-            assert distributions[f'top_level_{i}'] == ['all_distributions']
-            assert distributions[f'in_namespace_{i}'] == ['all_distributions']
-            assert distributions[f'in_package_{i}'] == ['all_distributions']
-
-        # All keys returned from packages_distributions() should be valid import
-        # names, which means that they must _at least_ be valid identifiers:
-        for import_name in distributions.keys():
-            assert import_name.isidentifier(), import_name
+            assert distributions[f'{i}-top-level'] == ['all_distributions']
+            assert distributions[f'{i}-in-namespace'] == ['all_distributions']
+            assert distributions[f'{i}-in-package'] == ['all_distributions']
 
 
 class PackagesDistributionsEggTest(

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -173,6 +173,7 @@ class NonASCIITests(fixtures.OnSysPath, fixtures.SiteDir, unittest.TestCase):
 class DiscoveryTests(
     fixtures.EggInfoPkg,
     fixtures.EggInfoPkgPipInstalledNoModules,
+    fixtures.EggInfoPkgSourcesFallback,
     fixtures.DistInfoPkg,
     unittest.TestCase,
 ):
@@ -181,6 +182,7 @@ class DiscoveryTests(
         assert all(isinstance(dist, Distribution) for dist in dists)
         assert any(dist.metadata['Name'] == 'egginfo-pkg' for dist in dists)
         assert any(dist.metadata['Name'] == 'empty_egg-pkg' for dist in dists)
+        assert any(dist.metadata['Name'] == 'starved_egg-pkg' for dist in dists)
         assert any(dist.metadata['Name'] == 'distinfo-pkg' for dist in dists)
 
     def test_invalid_usage(self):
@@ -312,6 +314,7 @@ class PackagesDistributionsPrebuiltTest(fixtures.ZipFixtures, unittest.TestCase)
 class PackagesDistributionsTest(
     fixtures.EggInfoPkg,
     fixtures.EggInfoPkgPipInstalledNoModules,
+    fixtures.EggInfoPkgSourcesFallback,
     fixtures.OnSysPath,
     fixtures.SiteDir,
     unittest.TestCase,
@@ -353,3 +356,7 @@ class PackagesDistributionsTest(
         # empty_egg-pkg should not be associated with any import names
         # (top_level.txt is empty, and installed-files.txt has no .py files)
         assert import_names_from_package('empty_egg-pkg') == set()
+
+        # starved_egg-pkg has one import ('starved_egg_pkg') inferred
+        # from SOURCES.txt (top_level.txt is missing)
+        assert import_names_from_package('starved_egg-pkg') == {'starved_egg_pkg'}

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -172,6 +172,7 @@ class NonASCIITests(fixtures.OnSysPath, fixtures.SiteDir, unittest.TestCase):
 
 class DiscoveryTests(
     fixtures.EggInfoPkg,
+    fixtures.EggInfoPkgPipInstalledNoToplevel,
     fixtures.EggInfoPkgPipInstalledNoModules,
     fixtures.EggInfoPkgSourcesFallback,
     fixtures.DistInfoPkg,
@@ -181,6 +182,7 @@ class DiscoveryTests(
         dists = list(distributions())
         assert all(isinstance(dist, Distribution) for dist in dists)
         assert any(dist.metadata['Name'] == 'egginfo-pkg' for dist in dists)
+        assert any(dist.metadata['Name'] == 'egg_with_module-pkg' for dist in dists)
         assert any(dist.metadata['Name'] == 'empty_egg-pkg' for dist in dists)
         assert any(dist.metadata['Name'] == 'starved_egg-pkg' for dist in dists)
         assert any(dist.metadata['Name'] == 'distinfo-pkg' for dist in dists)
@@ -365,6 +367,7 @@ class PackagesDistributionsTest(
 
 class PackagesDistributionsEggTest(
     fixtures.EggInfoPkg,
+    fixtures.EggInfoPkgPipInstalledNoToplevel,
     fixtures.EggInfoPkgPipInstalledNoModules,
     fixtures.EggInfoPkgSourcesFallback,
     unittest.TestCase,
@@ -385,6 +388,10 @@ class PackagesDistributionsEggTest(
 
         # egginfo-pkg declares one import ('mod') via top_level.txt
         assert import_names_from_package('egginfo-pkg') == {'mod'}
+
+        # egg_with_module-pkg has one import ('egg_with_module') inferred from
+        # installed-files.txt (top_level.txt is missing)
+        assert import_names_from_package('egg_with_module-pkg') == {'egg_with_module'}
 
         # empty_egg-pkg should not be associated with any import names
         # (top_level.txt is empty, and installed-files.txt has no .py files)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -342,10 +342,10 @@ class PackagesDistributionsTest(
         filenames = list(
             itertools.chain.from_iterable(
                 [
-                    f'{i}-top-level{suffix}',
-                    f'{i}-in-namespace/mod{suffix}',
-                    f'{i}-in-package/__init__.py',
-                    f'{i}-in-package/mod{suffix}',
+                    f'top_level_{i}{suffix}',
+                    f'in_namespace_{i}/mod{suffix}',
+                    f'in_package_{i}/__init__.py',
+                    f'in_package_{i}/mod{suffix}',
                 ]
                 for i, suffix in enumerate(suffixes)
             )
@@ -367,9 +367,14 @@ class PackagesDistributionsTest(
         distributions = packages_distributions()
 
         for i in range(len(suffixes)):
-            assert distributions[f'{i}-top-level'] == ['all_distributions']
-            assert distributions[f'{i}-in-namespace'] == ['all_distributions']
-            assert distributions[f'{i}-in-package'] == ['all_distributions']
+            assert distributions[f'top_level_{i}'] == ['all_distributions']
+            assert distributions[f'in_namespace_{i}'] == ['all_distributions']
+            assert distributions[f'in_package_{i}'] == ['all_distributions']
+
+        # All keys returned from packages_distributions() should be valid import
+        # names, which means that they must _at least_ be valid identifiers:
+        for import_name in distributions.keys():
+            assert import_name.isidentifier(), import_name
 
 
 class PackagesDistributionsEggTest(

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -3,7 +3,6 @@ import pickle
 import unittest
 import importlib
 import importlib_metadata
-import itertools
 import pyfakefs.fake_filesystem_unittest as ffs
 
 from . import fixtures
@@ -339,17 +338,6 @@ class PackagesDistributionsTest(
         Test top-level modules detected on a package without 'top-level.txt'.
         """
         suffixes = importlib.machinery.all_suffixes()
-        filenames = list(
-            itertools.chain.from_iterable(
-                [
-                    f'{i}-top-level{suffix}',
-                    f'{i}-in-namespace/mod{suffix}',
-                    f'{i}-in-package/__init__.py',
-                    f'{i}-in-package/mod{suffix}',
-                ]
-                for i, suffix in enumerate(suffixes)
-            )
-        )
         fixtures.build_files(
             {
                 'all_distributions-1.0.0.dist-info': {
@@ -357,12 +345,17 @@ class PackagesDistributionsTest(
                         Name: all_distributions
                         Version: 1.0.0
                     """,
-                    'RECORD': ''.join(f'{fname},,\n' for fname in filenames),
+                    'RECORD': ''.join(
+                        f'{i}-top-level{suffix},,\n'
+                        f'{i}-in-namespace/mod{suffix},,\n'
+                        f'{i}-in-package/__init__.py,,\n'
+                        f'{i}-in-package/mod{suffix},,\n'
+                        for i, suffix in enumerate(suffixes)
+                    ),
                 },
             },
             prefix=self.site_dir,
         )
-        fixtures.build_files({fname: "" for fname in filenames}, prefix=self.site_dir)
 
         distributions = packages_distributions()
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -184,7 +184,7 @@ class DiscoveryTests(
         assert any(dist.metadata['Name'] == 'egginfo-pkg' for dist in dists)
         assert any(dist.metadata['Name'] == 'egg_with_module-pkg' for dist in dists)
         assert any(dist.metadata['Name'] == 'empty_egg-pkg' for dist in dists)
-        assert any(dist.metadata['Name'] == 'starved_egg-pkg' for dist in dists)
+        assert any(dist.metadata['Name'] == 'sources_fallback-pkg' for dist in dists)
         assert any(dist.metadata['Name'] == 'distinfo-pkg' for dist in dists)
 
     def test_invalid_usage(self):
@@ -397,6 +397,6 @@ class PackagesDistributionsEggTest(
         # (top_level.txt is empty, and installed-files.txt has no .py files)
         assert import_names_from_package('empty_egg-pkg') == set()
 
-        # starved_egg-pkg has one import ('starved_egg_pkg') inferred
-        # from SOURCES.txt (top_level.txt is missing)
-        assert import_names_from_package('starved_egg-pkg') == {'starved_egg_pkg'}
+        # sources_fallback-pkg has one import ('sources_fallback') inferred from
+        # SOURCES.txt (top_level.txt and installed-files.txt is missing)
+        assert import_names_from_package('sources_fallback-pkg') == {'sources_fallback'}

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -183,7 +183,7 @@ class DiscoveryTests(
         assert all(isinstance(dist, Distribution) for dist in dists)
         assert any(dist.metadata['Name'] == 'egginfo-pkg' for dist in dists)
         assert any(dist.metadata['Name'] == 'egg_with_module-pkg' for dist in dists)
-        assert any(dist.metadata['Name'] == 'empty_egg-pkg' for dist in dists)
+        assert any(dist.metadata['Name'] == 'egg_with_no_modules-pkg' for dist in dists)
         assert any(dist.metadata['Name'] == 'sources_fallback-pkg' for dist in dists)
         assert any(dist.metadata['Name'] == 'distinfo-pkg' for dist in dists)
 
@@ -393,9 +393,9 @@ class PackagesDistributionsEggTest(
         # installed-files.txt (top_level.txt is missing)
         assert import_names_from_package('egg_with_module-pkg') == {'egg_with_module'}
 
-        # empty_egg-pkg should not be associated with any import names
+        # egg_with_no_modules-pkg should not be associated with any import names
         # (top_level.txt is empty, and installed-files.txt has no .py files)
-        assert import_names_from_package('empty_egg-pkg') == set()
+        assert import_names_from_package('egg_with_no_modules-pkg') == set()
 
         # sources_fallback-pkg has one import ('sources_fallback') inferred from
         # SOURCES.txt (top_level.txt and installed-files.txt is missing)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -312,12 +312,7 @@ class PackagesDistributionsPrebuiltTest(fixtures.ZipFixtures, unittest.TestCase)
 
 
 class PackagesDistributionsTest(
-    fixtures.EggInfoPkg,
-    fixtures.EggInfoPkgPipInstalledNoModules,
-    fixtures.EggInfoPkgSourcesFallback,
-    fixtures.OnSysPath,
-    fixtures.SiteDir,
-    unittest.TestCase,
+    fixtures.OnSysPath, fixtures.SiteDir, unittest.TestCase
 ):
     def test_packages_distributions_neither_toplevel_nor_files(self):
         """
@@ -367,6 +362,13 @@ class PackagesDistributionsTest(
             assert distributions[f'{i}-in-namespace'] == ['all_distributions']
             assert distributions[f'{i}-in-package'] == ['all_distributions']
 
+
+class PackagesDistributionsEggTest(
+    fixtures.EggInfoPkg,
+    fixtures.EggInfoPkgPipInstalledNoModules,
+    fixtures.EggInfoPkgSourcesFallback,
+    unittest.TestCase,
+):
     def test_packages_distributions_on_eggs(self):
         """
         Test old-style egg packages with a variation of 'top_level.txt',


### PR DESCRIPTION
The first three commits fix #115 for the case where a `.egg-info` package includes `installed-files.txt`:
We prefer `installed-files.txt` over `SOURCES.txt` as a source for `Distribution.files`, as the former is deemed more accurate when it is available.

The last two commits attempts to fix #115 for the case where we have no choice but to parse `SOURCES.txt`:
This _assumes_ that `Distribution.files` should never contain a path to a non-existent file.
We simply remove non-existent files with a filter, thus removing any entries from `SOURCES.txt` that refer to files that were part of the source package, but not part of the final installation.

Commits:
- `tests/fixtures`: Fix `FilesDef` type to include `bytes` values
- Add tests for egg-info package with no installed modules
- `Distribution.files`: Prefer `*.egg-info/installed-files.txt` to `SOURCES.txt`
- Add tests for egg-info package with `.files` from inaccurate `SOURCES.txt`
- `Distribution.files`: Only return files that actually exist
