### PR TITLE
Update main.yml permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,6 +2,9 @@ name: tests
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 env:
   # Environment variables to support color support (jaraco/skeleton#66):
   # Request colored output from CLI tools supporting it. Different tools
@@ -133,6 +136,8 @@ jobs:
     needs:
     - check
     if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
### Changes

Closes #438 

Looking at tox documentation, it does not seem to need id-token. Also I've looked into https://github.com/jaraco/jaraco.develop/blob/main/jaraco/develop/create-github-release.py and the permissions seems to be only `metadata: read` (which is always read) and `contents: write`(granted to the job).

The other jobs seems to need only contents read, but I wasn't able to check due to test failings.

See what you think and if I may be missing something.