### PR TITLE
Filter excess entries

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,10 @@
+v6.1.1
+======
+
+* #442: Fixed issue introduced in v6.1.0 where non-importable
+  names (metadata dirs) began appearing in
+  ``packages_distributions``.
+
 v6.1.0
 ======
 

--- a/importlib_metadata/__init__.py
+++ b/importlib_metadata/__init__.py
@@ -902,4 +902,9 @@ def _top_level_inferred(dist):
         f.parts[0] if len(f.parts) > 1 else inspect.getmodulename(f)
         for f in always_iterable(dist.files)
     }
-    return filter(None, opt_names)
+
+    @pass_none
+    def valid_module(name):
+        return name.isidentifier()
+
+    return filter(valid_module, opt_names)

--- a/importlib_metadata/__init__.py
+++ b/importlib_metadata/__init__.py
@@ -904,7 +904,7 @@ def _top_level_inferred(dist):
     }
 
     @pass_none
-    def valid_module(name):
-        return name.isidentifier()
+    def importable_name(name):
+        return '.' not in name
 
-    return filter(valid_module, opt_names)
+    return filter(importable_name, opt_names)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -360,5 +360,4 @@ class PackagesDistributionsTest(
         # All keys return from packages_distributions() should be valid
         # import names, which means that they must _at least_ be valid
         # identifiers:
-        for import_name in distributions.keys():
-            assert import_name.isidentifier(), import_name
+        assert all(import_name.isidentifier() for import_name in distributions.keys())

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -357,7 +357,8 @@ class PackagesDistributionsTest(
             assert distributions[f'in_namespace_{i}'] == ['all_distributions']
             assert distributions[f'in_package_{i}'] == ['all_distributions']
 
-        # All keys return from packages_distributions() should be valid import
-        # names, which means that they must _at least_ be valid identifiers:
+        # All keys return from packages_distributions() should be valid
+        # import names, which means that they must _at least_ be valid
+        # identifiers:
         for import_name in distributions.keys():
             assert import_name.isidentifier(), import_name

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -323,6 +323,9 @@ class PackagesDistributionsTest(
         )
         packages_distributions()
 
+    import pytest
+
+    @pytest.mark.xfail(reason="442")
     def test_packages_distributions_all_module_types(self):
         """
         Test top-level modules detected on a package without 'top-level.txt'.

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -339,10 +339,10 @@ class PackagesDistributionsTest(
                         Version: 1.0.0
                     """,
                     'RECORD': ''.join(
-                        f'{i}-top-level{suffix},,\n'
-                        f'{i}-in-namespace/mod{suffix},,\n'
-                        f'{i}-in-package/__init__.py,,\n'
-                        f'{i}-in-package/mod{suffix},,\n'
+                        f'top_level_{i}{suffix},,\n'
+                        f'in_namespace_{i}/mod{suffix},,\n'
+                        f'in_package_{i}/__init__.py,,\n'
+                        f'in_package_{i}/mod{suffix},,\n'
                         for i, suffix in enumerate(suffixes)
                     ),
                 },
@@ -353,6 +353,11 @@ class PackagesDistributionsTest(
         distributions = packages_distributions()
 
         for i in range(len(suffixes)):
-            assert distributions[f'{i}-top-level'] == ['all_distributions']
-            assert distributions[f'{i}-in-namespace'] == ['all_distributions']
-            assert distributions[f'{i}-in-package'] == ['all_distributions']
+            assert distributions[f'top_level_{i}'] == ['all_distributions']
+            assert distributions[f'in_namespace_{i}'] == ['all_distributions']
+            assert distributions[f'in_package_{i}'] == ['all_distributions']
+
+        # All keys return from packages_distributions() should be valid import
+        # names, which means that they must _at least_ be valid identifiers:
+        for import_name in distributions.keys():
+            assert import_name.isidentifier(), import_name

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -336,7 +336,7 @@ class PackagesDistributionsTest(
                         Version: 1.0.0
                     """,
                     'RECORD': ''.join(
-                        f'top_level_{i}{suffix},,\n'
+                        f'importable-name {i}{suffix},,\n'
                         f'in_namespace_{i}/mod{suffix},,\n'
                         f'in_package_{i}/__init__.py,,\n'
                         f'in_package_{i}/mod{suffix},,\n'
@@ -350,7 +350,7 @@ class PackagesDistributionsTest(
         distributions = packages_distributions()
 
         for i in range(len(suffixes)):
-            assert distributions[f'top_level_{i}'] == ['all_distributions']
+            assert distributions[f'importable-name {i}'] == ['all_distributions']
             assert distributions[f'in_namespace_{i}'] == ['all_distributions']
             assert distributions[f'in_package_{i}'] == ['all_distributions']
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -354,7 +354,9 @@ class PackagesDistributionsTest(
             assert distributions[f'in_namespace_{i}'] == ['all_distributions']
             assert distributions[f'in_package_{i}'] == ['all_distributions']
 
-        # All keys return from packages_distributions() should be valid
-        # import names, which means that they must _at least_ be valid
-        # identifiers:
-        assert all(import_name.isidentifier() for import_name in distributions.keys())
+        def is_importable(name):
+            return '.' not in name
+
+        # All keys returned from packages_distributions() should be
+        # importable.
+        assert all(map(is_importable, distributions))

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -323,9 +323,6 @@ class PackagesDistributionsTest(
         )
         packages_distributions()
 
-    import pytest
-
-    @pytest.mark.xfail(reason="442")
     def test_packages_distributions_all_module_types(self):
         """
         Test top-level modules detected on a package without 'top-level.txt'.


### PR DESCRIPTION
- Mark test as xfail as it's about to fail. Ref #442.
- Add test capturing missed expectation. Ref #442.
- 👹 Feed the hobgoblins (delint).
- Prefer all when asserting all.
- Filter non-identifiers from module names. Fixes #442.
