### PR TITLE
add .get() to the PackageMetadata protocol

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,10 @@
+v6.2.0
+======
+
+* #384: ``PackageMetadata`` now stipulates an additional ``get``
+  method allowing for easy querying of metadata keys that may not
+  be present.
+
 v6.1.0
 ======
 

--- a/importlib_metadata/_meta.py
+++ b/importlib_metadata/_meta.py
@@ -18,6 +18,14 @@ class PackageMetadata(Protocol):
     def __iter__(self) -> Iterator[str]:
         ...  # pragma: no cover
 
+    @overload
+    def get(self, name: str, failobj: None = None) -> Optional[str]:
+        ...  # pragma: no cover
+
+    @overload
+    def get(self, name: str, failobj: _T) -> Union[str, _T]:
+        ...  # pragma: no cover
+
     # overload per python/importlib_metadata#435
     @overload
     def get_all(self, name: str, failobj: None = None) -> Optional[List[Any]]:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -148,6 +148,20 @@ class APITests(
         with suppress_known_deprecation():
             assert md['does-not-exist'] is None
 
+    def test_get_key(self):
+        """
+        Getting a key gets the key.
+        """
+        md = metadata('egginfo-pkg')
+        assert md.get('Name') == 'egginfo-pkg'
+
+    def test_get_missing_key(self):
+        """
+        Requesting a missing key will return None.
+        """
+        md = metadata('distinfo-pkg')
+        assert md.get('does-not-exist') is None
+
     @staticmethod
     def _test_files(files):
         root = files[0].root


### PR DESCRIPTION
`__getitem__` warns that it will raise `KeyError` rather than returning `None` (I see #371 etc)

that's all very well but there's currently no comfortable way for users who anticipate missing values to write their code in a way that doesn't trigger that warning.  We seem to be steered towards
```python
import warnings
try:
    with warnings.catch_warnings():
        warnings.filterwarnings("ignore", "Implicit None .* KeyError", DeprecationWarning)
        value = metadata[key]
except KeyError:
    value = None
```
which sure seems like a lot of ceremony.

The natural way to do it would be just `value = metadata.get(key)`.  That method exists, but is not exposed by the protocol so if we try to use it then mypy shouts at us

Therefore add `get()` to that protocol (and testcases showing that it works).