### PR TITLE
Use jaraco.path for generating the record and files

### DIFF
--- a/tests/_path.py
+++ b/tests/_path.py
@@ -1,0 +1,104 @@
+# from jaraco.path 3.5
+
+import functools
+import pathlib
+from typing import Dict, Union
+
+try:
+    from typing import Protocol, runtime_checkable
+except ImportError:  # pragma: no cover
+    # Python 3.7
+    from typing_extensions import Protocol, runtime_checkable  # type: ignore
+
+
+FilesSpec = Dict[str, Union[str, bytes, 'FilesSpec']]  # type: ignore
+
+
+@runtime_checkable
+class TreeMaker(Protocol):
+    def __truediv__(self, *args, **kwargs):
+        ...  # pragma: no cover
+
+    def mkdir(self, **kwargs):
+        ...  # pragma: no cover
+
+    def write_text(self, content, **kwargs):
+        ...  # pragma: no cover
+
+    def write_bytes(self, content):
+        ...  # pragma: no cover
+
+
+def _ensure_tree_maker(obj: Union[str, TreeMaker]) -> TreeMaker:
+    return obj if isinstance(obj, TreeMaker) else pathlib.Path(obj)  # type: ignore
+
+
+def build(
+    spec: FilesSpec,
+    prefix: Union[str, TreeMaker] = pathlib.Path(),  # type: ignore
+):
+    """
+    Build a set of files/directories, as described by the spec.
+
+    Each key represents a pathname, and the value represents
+    the content. Content may be a nested directory.
+
+    >>> spec = {
+    ...     'README.txt': "A README file",
+    ...     "foo": {
+    ...         "__init__.py": "",
+    ...         "bar": {
+    ...             "__init__.py": "",
+    ...         },
+    ...         "baz.py": "# Some code",
+    ...     }
+    ... }
+    >>> target = getfixture('tmp_path')
+    >>> build(spec, target)
+    >>> target.joinpath('foo/baz.py').read_text(encoding='utf-8')
+    '# Some code'
+    """
+    for name, contents in spec.items():
+        create(contents, _ensure_tree_maker(prefix) / name)
+
+
+@functools.singledispatch
+def create(content: Union[str, bytes, FilesSpec], path):
+    path.mkdir(exist_ok=True)
+    build(content, prefix=path)  # type: ignore
+
+
+@create.register
+def _(content: bytes, path):
+    path.write_bytes(content)
+
+
+@create.register
+def _(content: str, path):
+    path.write_text(content, encoding='utf-8')
+
+
+class Recording:
+    """
+    A TreeMaker object that records everything that would be written.
+
+    >>> r = Recording()
+    >>> build({'foo': {'foo1.txt': 'yes'}, 'bar.txt': 'abc'}, r)
+    >>> r.record
+    ['foo/foo1.txt', 'bar.txt']
+    """
+
+    def __init__(self, loc=pathlib.PurePosixPath(), record=None):
+        self.loc = loc
+        self.record = record if record is not None else []
+
+    def __truediv__(self, other):
+        return Recording(self.loc / other, self.record)
+
+    def write_text(self, content, **kwargs):
+        self.record.append(str(self.loc))
+
+    write_bytes = write_text
+
+    def mkdir(self, **kwargs):
+        return

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -11,6 +11,9 @@ import contextlib
 from .py39compat import FS_NONASCII
 from typing import Dict, Union
 
+from . import _path
+
+
 try:
     from importlib import resources  # type: ignore
 
@@ -264,6 +267,16 @@ def build_files(file_defs, prefix=pathlib.Path()):
             else:
                 with full_name.open('w', encoding='utf-8') as f:
                     f.write(DALS(contents))
+
+
+def build_record(file_defs):
+    return ''.join(f'{name},,\n' for name in record_names(file_defs))
+
+
+def record_names(file_defs):
+    recording = _path.Recording()
+    _path.build(file_defs, recording)
+    return recording.record
 
 
 class FileBuilder:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -338,9 +338,8 @@ class PackagesDistributionsTest(
         files = {
             'all_distributions-1.0.0.dist-info': metadata,
         }
-        mod_files = {}
         for i, suffix in enumerate(suffixes):
-            mod_files.update(
+            files.update(
                 {
                     f'importable-name {i}{suffix}': '',
                     f'in_namespace_{i}': {
@@ -352,8 +351,7 @@ class PackagesDistributionsTest(
                     },
                 }
             )
-        all_files = dict(**files, **mod_files)
-        metadata.update(RECORD=fixtures.build_record(all_files))
+        metadata.update(RECORD=fixtures.build_record(files))
         fixtures.build_files(files, prefix=self.site_dir)
 
         distributions = packages_distributions()


### PR DESCRIPTION
- Vendor jaraco.path.build from jaraco.path 3.5
- Generate the files definition with the mod_files. Use 'build_record' to build the metadata RECORD from the files definition.
- Consolidate construction of files list, causing creation of the module files.
