### PR TITLE
type annotations

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,8 @@
+v6.6.0
+======
+
+* #449: Expanded type annotations.
+
 v6.3.0
 ======
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -64,6 +64,8 @@ intersphinx_mapping.update(
 nitpick_ignore = [
     # Workaround for #316
     ('py:class', 'importlib_metadata.EntryPoints'),
+    ('py:class', 'importlib_metadata.PackagePath'),
+    ('py:class', 'importlib_metadata.PathDistribution'),
     ('py:class', 'importlib_metadata.SelectableGroups'),
     ('py:class', 'importlib_metadata._meta._T'),
     # Workaround for #435

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -65,7 +65,6 @@ nitpick_ignore = [
     # Workaround for #316
     ('py:class', 'importlib_metadata.EntryPoints'),
     ('py:class', 'importlib_metadata.PackagePath'),
-    ('py:class', 'importlib_metadata.PathDistribution'),
     ('py:class', 'importlib_metadata.SelectableGroups'),
     ('py:class', 'importlib_metadata._meta._T'),
     # Workaround for #435

--- a/importlib_metadata/__init__.py
+++ b/importlib_metadata/__init__.py
@@ -5,6 +5,7 @@ import csv
 import sys
 import zipp
 import email
+import inspect
 import pathlib
 import operator
 import textwrap
@@ -14,7 +15,6 @@ import itertools
 import posixpath
 import contextlib
 import collections
-import inspect
 
 from . import _adapters, _meta, _py39compat
 from ._collections import FreezableDefaultDict, Pair
@@ -31,8 +31,9 @@ from contextlib import suppress
 from importlib import import_module
 from importlib.abc import MetaPathFinder
 from itertools import starmap
-from typing import List, Mapping, Optional, cast
+from typing import Iterator, List, Mapping, Optional, Set, Union, cast
 
+StrPath = Union[str, "os.PathLike[str]"]
 
 __all__ = [
     'Distribution',
@@ -53,11 +54,11 @@ __all__ = [
 class PackageNotFoundError(ModuleNotFoundError):
     """The package was not found."""
 
-    def __str__(self):
+    def __str__(self) -> str:
         return f"No package metadata was found for {self.name}"
 
     @property
-    def name(self):
+    def name(self) -> str:  # type: ignore[override]
         (name,) = self.args
         return name
 
@@ -123,8 +124,8 @@ class Sectioned:
             yield Pair(name, value)
 
     @staticmethod
-    def valid(line):
-        return line and not line.startswith('#')
+    def valid(line: str) -> bool:
+        return bool(line) and not line.startswith('#')
 
 
 class DeprecatedTuple:
@@ -198,7 +199,7 @@ class EntryPoint(DeprecatedTuple):
 
     dist: Optional['Distribution'] = None
 
-    def __init__(self, name, value, group):
+    def __init__(self, name: str, value: str, group: str) -> None:
         vars(self).update(name=name, value=value, group=group)
 
     def load(self):
@@ -212,18 +213,21 @@ class EntryPoint(DeprecatedTuple):
         return functools.reduce(getattr, attrs, module)
 
     @property
-    def module(self):
+    def module(self) -> str:
         match = self.pattern.match(self.value)
+        assert match is not None
         return match.group('module')
 
     @property
-    def attr(self):
+    def attr(self) -> str:
         match = self.pattern.match(self.value)
+        assert match is not None
         return match.group('attr')
 
     @property
-    def extras(self):
+    def extras(self) -> List[str]:
         match = self.pattern.match(self.value)
+        assert match is not None
         return re.findall(r'\w+', match.group('extras') or '')
 
     def _for(self, dist):
@@ -271,7 +275,7 @@ class EntryPoint(DeprecatedTuple):
             f'group={self.group!r})'
         )
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         return hash(self._key())
 
 
@@ -282,7 +286,7 @@ class EntryPoints(tuple):
 
     __slots__ = ()
 
-    def __getitem__(self, name):  # -> EntryPoint:
+    def __getitem__(self, name: str) -> EntryPoint:  # type: ignore[override]
         """
         Get the EntryPoint in self matching name.
         """
@@ -299,14 +303,14 @@ class EntryPoints(tuple):
         return EntryPoints(ep for ep in self if _py39compat.ep_matches(ep, **params))
 
     @property
-    def names(self):
+    def names(self) -> Set[str]:
         """
         Return the set of all names of all entry points.
         """
         return {ep.name for ep in self}
 
     @property
-    def groups(self):
+    def groups(self) -> Set[str]:
         """
         Return the set of all groups of all entry points.
         """
@@ -327,24 +331,28 @@ class EntryPoints(tuple):
 class PackagePath(pathlib.PurePosixPath):
     """A reference to a path in a package"""
 
-    def read_text(self, encoding='utf-8'):
+    hash: Optional["FileHash"]
+    size: int
+    dist: "Distribution"
+
+    def read_text(self, encoding: str = 'utf-8') -> str:  # type: ignore[override]
         with self.locate().open(encoding=encoding) as stream:
             return stream.read()
 
-    def read_binary(self):
+    def read_binary(self) -> bytes:
         with self.locate().open('rb') as stream:
             return stream.read()
 
-    def locate(self):
+    def locate(self) -> pathlib.Path:
         """Return a path-like object for this path"""
         return self.dist.locate_file(self)
 
 
 class FileHash:
-    def __init__(self, spec):
+    def __init__(self, spec: str) -> None:
         self.mode, _, self.value = spec.partition('=')
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f'<FileHash mode: {self.mode} value: {self.value}>'
 
 
@@ -360,14 +368,14 @@ class Distribution(metaclass=abc.ABCMeta):
         """
 
     @abc.abstractmethod
-    def locate_file(self, path):
+    def locate_file(self, path: StrPath) -> pathlib.Path:
         """
         Given a path to a file in this distribution, return a path
         to it.
         """
 
     @classmethod
-    def from_name(cls, name: str):
+    def from_name(cls, name: str) -> "Distribution":
         """Return the Distribution for the given package name.
 
         :param name: The name of the distribution package to search for.
@@ -385,14 +393,14 @@ class Distribution(metaclass=abc.ABCMeta):
             raise PackageNotFoundError(name)
 
     @classmethod
-    def discover(cls, **kwargs):
-        """Return an iterable of Distribution objects for all packages.
+    def discover(cls, **kwargs) -> Iterator["Distribution"]:
+        """Return an iterator of Distribution objects for all packages.
 
         Pass a ``context`` or pass keyword arguments for constructing
         a context.
 
         :context: A ``DistributionFinder.Context`` object.
-        :return: Iterable of Distribution objects for all packages.
+        :return: Iterator of Distribution objects for all packages.
         """
         context = kwargs.pop('context', None)
         if context and kwargs:
@@ -403,7 +411,7 @@ class Distribution(metaclass=abc.ABCMeta):
         )
 
     @staticmethod
-    def at(path):
+    def at(path: StrPath) -> "PathDistribution":
         """Return a Distribution for the indicated metadata path
 
         :param path: a string or path-like object
@@ -438,7 +446,7 @@ class Distribution(metaclass=abc.ABCMeta):
         return _adapters.Message(email.message_from_string(text))
 
     @property
-    def name(self):
+    def name(self) -> str:
         """Return the 'Name' metadata for the distribution package."""
         return self.metadata['Name']
 
@@ -448,16 +456,16 @@ class Distribution(metaclass=abc.ABCMeta):
         return Prepared.normalize(self.name)
 
     @property
-    def version(self):
+    def version(self) -> str:
         """Return the 'Version' metadata for the distribution package."""
         return self.metadata['Version']
 
     @property
-    def entry_points(self):
+    def entry_points(self) -> EntryPoints:
         return EntryPoints._from_text_for(self.read_text('entry_points.txt'), self)
 
     @property
-    def files(self):
+    def files(self) -> Optional[List[PackagePath]]:
         """Files in this distribution.
 
         :return: List of PackagePath for this distribution or None
@@ -540,7 +548,7 @@ class Distribution(metaclass=abc.ABCMeta):
         return text and map('"{}"'.format, text.splitlines())
 
     @property
-    def requires(self):
+    def requires(self) -> Optional[List[str]]:
         """Generated requirements specified for this Distribution"""
         reqs = self._read_dist_info_reqs() or self._read_egg_info_reqs()
         return reqs and list(reqs)
@@ -619,7 +627,7 @@ class DistributionFinder(MetaPathFinder):
             vars(self).update(kwargs)
 
         @property
-        def path(self):
+        def path(self) -> List[str]:
             """
             The sequence of directory path that a distribution finder
             should search.
@@ -630,11 +638,11 @@ class DistributionFinder(MetaPathFinder):
             return vars(self).get('path', sys.path)
 
     @abc.abstractmethod
-    def find_distributions(self, context=Context()):
+    def find_distributions(self, context=Context()) -> Iterator[Distribution]:
         """
         Find distributions.
 
-        Return an iterable of all Distribution instances capable of
+        Return an iterator of all Distribution instances capable of
         loading the metadata for packages matching the ``context``,
         a DistributionFinder.Context instance.
         """
@@ -765,11 +773,13 @@ class MetadataPathFinder(NullFinder, DistributionFinder):
     of Python that do not have a PathFinder find_distributions().
     """
 
-    def find_distributions(self, context=DistributionFinder.Context()):
+    def find_distributions(
+        self, context=DistributionFinder.Context()
+    ) -> Iterator["PathDistribution"]:
         """
         Find distributions.
 
-        Return an iterable of all Distribution instances capable of
+        Return an iterator of all Distribution instances capable of
         loading the metadata for packages matching ``context.name``
         (or all names if ``None`` indicated) along the paths in the list
         of directories ``context.path``.
@@ -785,19 +795,19 @@ class MetadataPathFinder(NullFinder, DistributionFinder):
             path.search(prepared) for path in map(FastPath, paths)
         )
 
-    def invalidate_caches(cls):
+    def invalidate_caches(cls) -> None:
         FastPath.__new__.cache_clear()
 
 
 class PathDistribution(Distribution):
-    def __init__(self, path: SimplePath):
+    def __init__(self, path: SimplePath) -> None:
         """Construct a distribution.
 
         :param path: SimplePath indicating the metadata directory.
         """
         self._path = path
 
-    def read_text(self, filename):
+    def read_text(self, filename: StrPath) -> Optional[str]:
         with suppress(
             FileNotFoundError,
             IsADirectoryError,
@@ -807,9 +817,11 @@ class PathDistribution(Distribution):
         ):
             return self._path.joinpath(filename).read_text(encoding='utf-8')
 
+        return None
+
     read_text.__doc__ = Distribution.read_text.__doc__
 
-    def locate_file(self, path):
+    def locate_file(self, path: StrPath) -> pathlib.Path:
         return self._path.parent / path
 
     @property
@@ -842,7 +854,7 @@ class PathDistribution(Distribution):
         return name
 
 
-def distribution(distribution_name):
+def distribution(distribution_name) -> Distribution:
     """Get the ``Distribution`` instance for the named package.
 
     :param distribution_name: The name of the distribution package as a string.
@@ -851,10 +863,10 @@ def distribution(distribution_name):
     return Distribution.from_name(distribution_name)
 
 
-def distributions(**kwargs):
+def distributions(**kwargs) -> Iterator[Distribution]:
     """Get all ``Distribution`` instances in the current environment.
 
-    :return: An iterable of ``Distribution`` instances.
+    :return: An iterator of ``Distribution`` instances.
     """
     return Distribution.discover(**kwargs)
 
@@ -868,7 +880,7 @@ def metadata(distribution_name) -> _meta.PackageMetadata:
     return Distribution.from_name(distribution_name).metadata
 
 
-def version(distribution_name):
+def version(distribution_name) -> str:
     """Get the version string for the named package.
 
     :param distribution_name: The name of the distribution package to query.
@@ -902,7 +914,7 @@ def entry_points(**params) -> EntryPoints:
     return EntryPoints(eps).select(**params)
 
 
-def files(distribution_name):
+def files(distribution_name) -> Optional[List[PackagePath]]:
     """Return a list of files for the named package.
 
     :param distribution_name: The name of the distribution package to query.
@@ -911,7 +923,7 @@ def files(distribution_name):
     return distribution(distribution_name).files
 
 
-def requires(distribution_name):
+def requires(distribution_name) -> Optional[List[str]]:
     """
     Return a list of requirements for the named package.
 

--- a/importlib_metadata/_compat.py
+++ b/importlib_metadata/_compat.py
@@ -1,5 +1,8 @@
+import os
 import sys
 import platform
+
+from typing import Union
 
 
 __all__ = ['install', 'NullFinder', 'Protocol']
@@ -70,3 +73,10 @@ def pypy_partial(val):
     """
     is_pypy = platform.python_implementation() == 'PyPy'
     return val + is_pypy
+
+
+if sys.version_info >= (3, 9):
+    StrPath = Union[str, os.PathLike[str]]
+else:
+    # PathLike is only subscriptable at runtime in 3.9+
+    StrPath = Union[str, "os.PathLike[str]"]  # pragma: no cover

--- a/importlib_metadata/_meta.py
+++ b/importlib_metadata/_meta.py
@@ -49,7 +49,7 @@ class SimplePath(Protocol[_T]):
     A minimal subset of pathlib.Path required by PathDistribution.
     """
 
-    def joinpath(self) -> _T:
+    def joinpath(self, other: Union[str, _T]) -> _T:
         ...  # pragma: no cover
 
     def __truediv__(self, other: Union[str, _T]) -> _T:


### PR DESCRIPTION
It's kind of annoying that this library publishes a py.typed, but most of the API is not type-annotated.  Users who check their own code with mypy are obliged to scatter around `# type: ignore[no-untyped-call]` comments.

Possible points of interest:
- `joinpath` on the `SimplePath` seems to have been just wrong
- I've annotated some `Iterable`s as `Iterator`s, because (i) they are and (ii) `Distribution.from_name()` relies on this when it calls `next(..)` rather than `next(iter(..))`

This MR doesn't annotate the whole API: I've ducked the slightly difficult ones like `distributions()`, `select()` and `matches()`.  typeshed has annotations that are presumably satisfactory in practice, but it looks as though applying them here would be more invasive than I intend to be in this commit.  https://github.com/python/typeshed/blob/main/stdlib/importlib/metadata/__init__.pyi

This MR is a long way from annotating the whole project - `mypy --strict importlib_metadata` reports 171 errors, so it would take a bit more of a campaign to work through that.