### PR TITLE
Fix path handling and masked errors on Windows for installed-files.txt

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,10 @@
+v6.5.1
+======
+
+* python/cpython#103661: Removed excess error suppression in
+  ``_read_files_egginfo_installed`` and fixed path handling
+  on Windows.
+
 v6.5.0
 ======
 

--- a/importlib_metadata/__init__.py
+++ b/importlib_metadata/__init__.py
@@ -536,12 +536,12 @@ class Distribution(DeprecatedNonAbstract):
         subdir = getattr(self, '_path', None)
         if not text or not subdir:
             return
-        with contextlib.suppress(Exception):
-            ret = [
-                str((subdir / line).resolve().relative_to(self.locate_file('')))
-                for line in text.splitlines()
-            ]
-            return map('"{}"'.format, ret)
+
+        ret = [
+            str((subdir / line).resolve().relative_to(self.locate_file('').resolve()))
+            for line in text.splitlines()
+        ]
+        return map('"{}"'.format, ret)
 
     def _read_files_egginfo_sources(self):
         """

--- a/importlib_metadata/__init__.py
+++ b/importlib_metadata/__init__.py
@@ -538,7 +538,10 @@ class Distribution(DeprecatedNonAbstract):
             return
 
         ret = [
-            str((subdir / line).resolve().relative_to(self.locate_file('').resolve()))
+            (subdir / line)
+            .resolve()
+            .relative_to(self.locate_file('').resolve())
+            .as_posix()
             for line in text.splitlines()
         ]
         return map('"{}"'.format, ret)


### PR DESCRIPTION
- Resolve the located directory and remove suppression of Exceptions. Ref python/cpython#103661.
- Wrap 'subdir/line' in PosixPath to ensure the output uses posix path separators. Ref python/cpython#103661.
