### PR TITLE
Add EntryPoints.__repr__

### DIFF
--- a/importlib_metadata/__init__.py
+++ b/importlib_metadata/__init__.py
@@ -293,6 +293,14 @@ class EntryPoints(tuple):
         except StopIteration:
             raise KeyError(name)
 
+    def __repr__(self):
+        """
+        Repr with classname and tuple constructor to
+        signal that we deviate from regular tuple behavior.
+        """
+        return '%s(%r)' % (self.__class__.__name__, tuple(self))
+        
+        
     def select(self, **params):
         """
         Select entry points from self that match the


### PR DESCRIPTION
@jaraco  With commit 0c819641d314ac496eb32b55f2b15215fa6fa55f the behavior of Entrypoints gets a bit disorienting.
Being unfamiliar with the EntryPoints API I fired up ipython and inspected the result of selecting some entry-point I am interested in.
The representation is that of a  regular tuple:

(EntryPoint(name='py.test', value='pytest:console_main', group='console_scripts'),
 EntryPoint(name='pytest', value='pytest:console_main', group='console_scripts'),
 EntryPoint(name='humanfriendly', value='humanfriendly.cli:main', group='console_scripts'))

My expectation was that the collection should act like a tuple which can be indexed by integers. Would you be open to accept the custom  `__repr__` in this PR ?
I gather that Entrypoints at this point is essentially an immutable OrderedDict with some convenience selectors/filters. Is this correct?
Alternatively you could consider vendoring [frozenordereddict](https://github.com/wsmith323/frozenordereddict/blob/master/frozenordereddict/__init__.py) (I haven't tried it myself).
