### PR TITLE
Add support for egg packages with files outside site-packages

### DIFF
--- a/importlib_metadata/_meta.py
+++ b/importlib_metadata/_meta.py
@@ -70,3 +70,6 @@ class SimplePath(Protocol):
 
     def exists(self) -> bool:
         ...  # pragma: no cover
+
+    def resolve(self) -> bool:
+        ...  # pragma: no cover

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -252,6 +252,40 @@ class EggInfoPkgPipInstalledNoToplevel(OnSysPath, SiteBuilder):
     }
 
 
+class EggInfoPkgPipInstalledExternalDataFiles(OnSysPath, SiteBuilder):
+    files: FilesSpec = {
+        "egg_with_module_pkg.egg-info": {
+            "PKG-INFO": "Name: egg_with_module-pkg",
+            # SOURCES.txt is made from the source archive, and contains files
+            # (setup.py) that are not present after installation.
+            "SOURCES.txt": """
+                egg_with_module.py
+                setup.py
+                egg_with_module.json
+                egg_with_module_pkg.egg-info/PKG-INFO
+                egg_with_module_pkg.egg-info/SOURCES.txt
+                egg_with_module_pkg.egg-info/top_level.txt
+            """,
+            # installed-files.txt is written by pip, and is a strictly more
+            # accurate source than SOURCES.txt as to the installed contents of
+            # the package.
+            "installed-files.txt": """
+                ../../../etc/jupyter/jupyter_notebook_config.d/egg_with_module.json
+                ../egg_with_module.py
+                PKG-INFO
+                SOURCES.txt
+                top_level.txt
+            """,
+            # missing top_level.txt (to trigger fallback to installed-files.txt)
+        },
+        "egg_with_module.py": """
+            def main():
+                print("hello world")
+            """,
+    }
+
+
+
 class EggInfoPkgPipInstalledNoModules(OnSysPath, SiteBuilder):
     files: FilesSpec = {
         "egg_with_no_modules_pkg.egg-info": {

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -29,6 +29,7 @@ class APITests(
     fixtures.EggInfoPkg,
     fixtures.EggInfoPkgPipInstalledNoToplevel,
     fixtures.EggInfoPkgPipInstalledNoModules,
+    fixtures.EggInfoPkgPipInstalledExternalDataFiles,
     fixtures.EggInfoPkgSourcesFallback,
     fixtures.DistInfoPkg,
     fixtures.DistInfoPkgWithDot,


### PR DESCRIPTION
This should fix #455. I slightly modified the patch suggested by @jaraco in https://github.com/python/importlib_metadata/issues/455#issuecomment-1837571288 so that we don't have to call `self.locate_file('').resolve()` for `name` in `text.splitlines()`, and fixed one type complaint I was getting locally.

I'm not sure if the test I added works properly (which is one of the reasons I made this PR), because I'm running into a weird `tox` issue locally.