### PR TITLE
Add typing for load and select

### DIFF
--- a/importlib_metadata/__init__.py
+++ b/importlib_metadata/__init__.py
@@ -33,7 +33,7 @@ from contextlib import suppress
 from importlib import import_module
 from importlib.abc import MetaPathFinder
 from itertools import starmap
-from typing import Iterable, List, Mapping, Optional, Set, cast, Any
+from typing import Any, Iterable, List, Mapping, Optional, Set, cast
 
 __all__ = [
     'Distribution',

--- a/importlib_metadata/__init__.py
+++ b/importlib_metadata/__init__.py
@@ -33,7 +33,7 @@ from contextlib import suppress
 from importlib import import_module
 from importlib.abc import MetaPathFinder
 from itertools import starmap
-from typing import Any, Iterable, List, Mapping, Optional, Set, cast
+from typing import Any, Iterable, List, Mapping, Match, Optional, Set, cast
 
 __all__ = [
     'Distribution',
@@ -180,7 +180,7 @@ class EntryPoint:
         is indicated by the value, return that module. Otherwise,
         return the named object.
         """
-        match = self.pattern.match(self.value)
+        match = cast(Match, self.pattern.match(self.value))
         module = import_module(match.group('module'))
         attrs = filter(None, (match.group('attr') or '').split('.'))
         return functools.reduce(getattr, attrs, module)
@@ -769,6 +769,7 @@ class Lookup:
     """
     A micro-optimized class for searching a (fast) path for metadata.
     """
+
     def __init__(self, path: FastPath):
         """
         Calculate all of the children representing metadata.

--- a/importlib_metadata/__init__.py
+++ b/importlib_metadata/__init__.py
@@ -33,7 +33,7 @@ from contextlib import suppress
 from importlib import import_module
 from importlib.abc import MetaPathFinder
 from itertools import starmap
-from typing import Iterable, List, Mapping, Optional, Set, cast
+from typing import Iterable, List, Mapping, Optional, Set, cast, Any
 
 __all__ = [
     'Distribution',
@@ -175,7 +175,7 @@ class EntryPoint:
     def __init__(self, name: str, value: str, group: str) -> None:
         vars(self).update(name=name, value=value, group=group)
 
-    def load(self):
+    def load(self) -> Any:
         """Load the entry point from its definition. If only a module
         is indicated by the value, return that module. Otherwise,
         return the named object.

--- a/importlib_metadata/__init__.py
+++ b/importlib_metadata/__init__.py
@@ -275,7 +275,7 @@ class EntryPoints(tuple):
         """
         return '%s(%r)' % (self.__class__.__name__, tuple(self))
 
-    def select(self, **params):
+    def select(self, **params) -> EntryPoints:
         """
         Select entry points from self that match the
         given parameters (typically group and/or name).


### PR DESCRIPTION
**Changes**

- Added typing for the `Entrypoint.load()` and the `Entrypoints.select()` method.

As the `Entrypoint.load()` returns more than one type depending on the value of the `value` variable, it was necessary to set it as `Any`.
