### PR TITLE
Remove deprecated constructs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -69,6 +69,4 @@ nitpick_ignore = [
     ('py:class', 'importlib_metadata._meta._T'),
     # Workaround for #435
     ('py:class', '_T'),
-    # Other workarounds
-    ('py:class', 'importlib_metadata.DeprecatedNonAbstract'),
 ]

--- a/importlib_metadata/__init__.py
+++ b/importlib_metadata/__init__.py
@@ -12,7 +12,6 @@ import inspect
 import pathlib
 import operator
 import textwrap
-import warnings
 import functools
 import itertools
 import posixpath
@@ -334,27 +333,7 @@ class FileHash:
         return f'<FileHash mode: {self.mode} value: {self.value}>'
 
 
-class DeprecatedNonAbstract:
-    # Required until Python 3.14
-    def __new__(cls, *args, **kwargs):
-        all_names = {
-            name for subclass in inspect.getmro(cls) for name in vars(subclass)
-        }
-        abstract = {
-            name
-            for name in all_names
-            if getattr(getattr(cls, name), '__isabstractmethod__', False)
-        }
-        if abstract:
-            warnings.warn(
-                f"Unimplemented abstract methods {abstract}",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-        return super().__new__(cls)
-
-
-class Distribution(DeprecatedNonAbstract):
+class Distribution(metaclass=abc.ABCMeta):
     """
     An abstract Python distribution package.
 

--- a/importlib_metadata/_adapters.py
+++ b/importlib_metadata/_adapters.py
@@ -1,20 +1,8 @@
-import functools
-import warnings
 import re
 import textwrap
 import email.message
 
 from ._text import FoldedCase
-from ._compat import pypy_partial
-
-
-# Do not remove prior to 2024-01-01 or Python 3.14
-_warn = functools.partial(
-    warnings.warn,
-    "Implicit None on return values is deprecated and will raise KeyErrors.",
-    DeprecationWarning,
-    stacklevel=pypy_partial(2),
-)
 
 
 class Message(email.message.Message):
@@ -53,12 +41,17 @@ class Message(email.message.Message):
 
     def __getitem__(self, item):
         """
-        Warn users that a ``KeyError`` can be expected when a
-        missing key is supplied. Ref python/importlib_metadata#371.
+        Override parent behavior to typical dict behavior.
+
+        ``email.message.Message`` will emit None values for missing
+        keys. Typical mappings, including this ``Message``, will raise
+        a key error for missing keys.
+
+        Ref python/importlib_metadata#371.
         """
         res = super().__getitem__(item)
         if res is None:
-            _warn()
+            raise KeyError(item)
         return res
 
     def _repair_headers(self):

--- a/newsfragments/+8256a9d7.removal.rst
+++ b/newsfragments/+8256a9d7.removal.rst
@@ -1,0 +1,1 @@
+Removed deprecated support for Distribution subclasses not implementing abstract methods.

--- a/newsfragments/371.removal.rst
+++ b/newsfragments/371.removal.rst
@@ -1,0 +1,1 @@
+Message.__getitem__ now raises a KeyError on missing keys.

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,9 +1,7 @@
 import re
 import textwrap
 import unittest
-import warnings
 import importlib
-import contextlib
 
 from . import fixtures
 from importlib_metadata import (
@@ -16,13 +14,6 @@ from importlib_metadata import (
     requires,
     version,
 )
-
-
-@contextlib.contextmanager
-def suppress_known_deprecation():
-    with warnings.catch_warnings(record=True) as ctx:
-        warnings.simplefilter('default', category=DeprecationWarning)
-        yield ctx
 
 
 class APITests(
@@ -157,13 +148,13 @@ class APITests(
         resolved = version('importlib-metadata')
         assert re.match(self.version_pattern, resolved)
 
-    def test_missing_key_legacy(self):
+    def test_missing_key(self):
         """
-        Requesting a missing key will still return None, but warn.
+        Requesting a missing key raises KeyError.
         """
         md = metadata('distinfo-pkg')
-        with suppress_known_deprecation():
-            assert md['does-not-exist'] is None
+        with self.assertRaises(KeyError):
+            md['does-not-exist']
 
     def test_get_key(self):
         """

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,16 +1,13 @@
 import re
 import pickle
 import unittest
-import warnings
 import importlib
 import importlib_metadata
-import contextlib
 from .compat.py39 import os_helper
 
 import pyfakefs.fake_filesystem_unittest as ffs
 
 from . import fixtures
-from ._context import suppress
 from ._path import Symlink
 from importlib_metadata import (
     Distribution,
@@ -23,13 +20,6 @@ from importlib_metadata import (
     packages_distributions,
     version,
 )
-
-
-@contextlib.contextmanager
-def suppress_known_deprecation():
-    with warnings.catch_warnings(record=True) as ctx:
-        warnings.simplefilter('default', category=DeprecationWarning)
-        yield ctx
 
 
 class BasicTests(fixtures.DistInfoPkg, unittest.TestCase):
@@ -56,9 +46,6 @@ class BasicTests(fixtures.DistInfoPkg, unittest.TestCase):
 
         assert "metadata" in str(ctx.exception)
 
-    # expected to fail until ABC is enforced
-    @suppress(AssertionError)
-    @suppress_known_deprecation()
     def test_abc_enforced(self):
         with self.assertRaises(TypeError):
             type('DistributionSubclass', (Distribution,), {})()


### PR DESCRIPTION
- **Removed deprecated support for Distribution subclasses not implementing abstract methods.**
- **Message.__getitem__ now raises a KeyError on missing keys.**
