### PR TITLE
zipp version CVE-2024-5569

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,8 @@ classifiers = [
 ]
 requires-python = ">=3.8"
 dependencies = [
-	"zipp>=0.5",
+	"zipp>=0.5"; python_version < "3.8"',
+	"zipp>=3.19.1"; python_version >= "3.8"',
 	'typing-extensions>=3.6.4; python_version < "3.8"',
 ]
 dynamic = ["version"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,8 +18,7 @@ classifiers = [
 ]
 requires-python = ">=3.8"
 dependencies = [
-	"zipp>=0.5"; python_version < "3.8"',
-	"zipp>=3.19.1"; python_version >= "3.8"',
+	"zipp>=3.19.1",
 	'typing-extensions>=3.6.4; python_version < "3.8"',
 ]
 dynamic = ["version"]


### PR DESCRIPTION
To address [CVE-2024-5569](https://github.com/advisories/GHSA-jfmj-5v4g-7637) vulnerability issue,
updated zipp version.

Related git issue: https://github.com/python/importlib_metadata/issues/495