### PR TITLE
Speed up import time by deferring inspect

### DIFF
--- a/importlib_metadata/__init__.py
+++ b/importlib_metadata/__init__.py
@@ -1088,7 +1088,7 @@ def _get_toplevel_name(name: PackagePath) -> str:
     >>> _get_toplevel_name(PackagePath('foo.dist-info'))
     'foo.dist-info'
     """
-    # We're deffering import of inspect to speed up overall import time
+    # Defer import of inspect for performance (python/cpython#118761)
     import inspect
 
     return _topmost(name) or (

--- a/importlib_metadata/__init__.py
+++ b/importlib_metadata/__init__.py
@@ -1088,13 +1088,14 @@ def _get_toplevel_name(name: PackagePath) -> str:
     >>> _get_toplevel_name(PackagePath('foo.dist-info'))
     'foo.dist-info'
     """
-    if n := _topmost(name):
-        return n
-
     # We're deffering import of inspect to speed up overall import time
     import inspect
 
-    return inspect.getmodulename(name) or str(name)
+    return _topmost(name) or (
+        # python/typeshed#10328
+        inspect.getmodulename(name)  # type: ignore
+        or str(name)
+    )
 
 
 def _top_level_inferred(dist):

--- a/importlib_metadata/__init__.py
+++ b/importlib_metadata/__init__.py
@@ -1070,9 +1070,6 @@ def _topmost(name: PackagePath) -> Optional[str]:
     return top if rest else None
 
 
-inspect = None
-
-
 def _get_toplevel_name(name: PackagePath) -> str:
     """
     Infer a possibly importable module name from a name presumed on
@@ -1091,13 +1088,12 @@ def _get_toplevel_name(name: PackagePath) -> str:
     >>> _get_toplevel_name(PackagePath('foo.dist-info'))
     'foo.dist-info'
     """
-    n = _topmost(name)
-    if n:
+    if n := _topmost(name):
         return n
 
-    global inspect
-    if inspect is None:
-        import inspect
+    # We're deffering import of inspect to speed up overall import time
+    import inspect
+
     return inspect.getmodulename(name) or str(name)
 
 

--- a/importlib_metadata/__init__.py
+++ b/importlib_metadata/__init__.py
@@ -8,7 +8,6 @@ import json
 import zipp
 import email
 import types
-import inspect
 import pathlib
 import operator
 import textwrap
@@ -1071,6 +1070,9 @@ def _topmost(name: PackagePath) -> Optional[str]:
     return top if rest else None
 
 
+inspect = None
+
+
 def _get_toplevel_name(name: PackagePath) -> str:
     """
     Infer a possibly importable module name from a name presumed on
@@ -1089,11 +1091,14 @@ def _get_toplevel_name(name: PackagePath) -> str:
     >>> _get_toplevel_name(PackagePath('foo.dist-info'))
     'foo.dist-info'
     """
-    return _topmost(name) or (
-        # python/typeshed#10328
-        inspect.getmodulename(name)  # type: ignore
-        or str(name)
-    )
+    n = _topmost(name)
+    if n:
+        return n
+
+    global inspect
+    if inspect is None:
+        import inspect
+    return inspect.getmodulename(name) or str(name)
 
 
 def _top_level_inferred(dist):


### PR DESCRIPTION
Deferring import of `inspect` cuts the import time by ~10% (4ms on my machine).

CPython issue: https://github.com/python/cpython/issues/118761

I haven't been able to run the tests locally, seeing these errors:

```
RROR tests/test_api.py - AttributeError: module 'tests.fixtures' has no attribute 'EggInfoPkg'
ERROR tests/test_integration.py - AttributeError: module 'tests.fixtures' has no attribute 'DistInfoPkg'
ERROR tests/test_main.py
ERROR tests/test_zip.py - AttributeError: module 'tests.fixtures' has no attribute 'ZipFixtures'
```

## Benchmarks

These have been run with latest CPython main branch (as of Aug 6th 2024), these gains are likely representative for Python 3.13, but not 3.12.

#### this PR

```console
❯ hyperfine -w 5 'python -c "import importlib_metadata"'
Benchmark 1: python -c "import importlib_metadata"
  Time (mean ± σ):      39.6 ms ±   4.6 ms    [User: 29.8 ms, System: 9.4 ms]
  Range (min … max):    29.7 ms …  49.8 ms    68 runs
```

#### main

```console
❯ hyperfine -w 5 'python -c "import importlib_metadata"'
Benchmark 1: python -c "import importlib_metadata"
  Time (mean ± σ):      43.4 ms ±   3.6 ms    [User: 33.1 ms, System: 9.8 ms]
  Range (min … max):    34.9 ms …  50.1 ms    68 runs
```
