### PR TITLE
Defer import of zipp

### DIFF
--- a/importlib_metadata/__init__.py
+++ b/importlib_metadata/__init__.py
@@ -29,8 +29,6 @@ from importlib.abc import MetaPathFinder
 from itertools import starmap
 from typing import Any, Iterable, List, Mapping, Match, Optional, Set, cast
 
-from zipp.compat.overlay import zipfile
-
 from . import _meta
 from ._collections import FreezableDefaultDict, Pair
 from ._compat import (
@@ -777,6 +775,8 @@ class FastPath:
         return []
 
     def zip_children(self):
+        from zipp.compat.overlay import zipfile
+
         zip_path = zipfile.Path(self.root)
         names = zip_path.root.namelist()
         self.joinpath = zip_path.joinpath

--- a/importlib_metadata/__init__.py
+++ b/importlib_metadata/__init__.py
@@ -775,6 +775,7 @@ class FastPath:
         return []
 
     def zip_children(self):
+        # deferred for performance (python/importlib_metadata#502)
         from zipp.compat.overlay import zipfile
 
         zip_path = zipfile.Path(self.root)

--- a/newsfragments/502.feature.rst
+++ b/newsfragments/502.feature.rst
@@ -1,0 +1,1 @@
+Deferred import of zipfile.Path


### PR DESCRIPTION
Impoting zipp takes between 2-4 ms on my machine, which is at least 10% of overall import time of the `importlib_metadata` package (depending on Python version). Since this package is only used in a single code path it makes sense to defer it.

![image](https://github.com/user-attachments/assets/c462eda9-a40a-40d6-b8da-8a3d95f874ee)

To estimate the cost of repeatedly calling `import zipp` I ran

```console
❯ python -m timeit -s "import zipp"  "import zipp"
5000000 loops, best of 5: 59.9 nsec per loop
```
(this is with cpython main branch)

Since this is in a codepath that reads a zipfile from disk, this overhead is negligible.