### PR TITLE
Defer import of json and zipp

### DIFF
--- a/importlib_metadata/__init__.py
+++ b/importlib_metadata/__init__.py
@@ -14,7 +14,6 @@ import collections
 import email
 import functools
 import itertools
-import json
 import operator
 import os
 import pathlib
@@ -673,6 +672,8 @@ class Distribution(metaclass=abc.ABCMeta):
         return self._load_json('direct_url.json')
 
     def _load_json(self, filename):
+        import json
+
         return pass_none(json.loads)(
             self.read_text(filename),
             object_hook=lambda data: types.SimpleNamespace(**data),

--- a/importlib_metadata/__init__.py
+++ b/importlib_metadata/__init__.py
@@ -29,8 +29,6 @@ from importlib.abc import MetaPathFinder
 from itertools import starmap
 from typing import Any, Iterable, List, Mapping, Match, Optional, Set, cast
 
-from zipp.compat.overlay import zipfile
-
 from . import _meta
 from ._collections import FreezableDefaultDict, Pair
 from ._compat import (
@@ -777,6 +775,8 @@ class FastPath:
         return []
 
     def zip_children(self):
+        from zipp.compat.overlay import zipfile
+
         zip_path = zipfile.Path(self.root)
         names = zip_path.root.namelist()
         self.joinpath = zip_path.joinpath

--- a/importlib_metadata/__init__.py
+++ b/importlib_metadata/__init__.py
@@ -672,6 +672,7 @@ class Distribution(metaclass=abc.ABCMeta):
         return self._load_json('direct_url.json')
 
     def _load_json(self, filename):
+        # Deferred for performance (python/importlib_metadata#503)
         import json
 
         return pass_none(json.loads)(

--- a/importlib_metadata/_compat.py
+++ b/importlib_metadata/_compat.py
@@ -1,3 +1,4 @@
+import platform
 import sys
 
 __all__ = ['install', 'NullFinder']
@@ -51,7 +52,5 @@ def pypy_partial(val):
 
     Workaround for #327.
     """
-    import platform
-
     is_pypy = platform.python_implementation() == 'PyPy'
     return val + is_pypy

--- a/importlib_metadata/_compat.py
+++ b/importlib_metadata/_compat.py
@@ -1,4 +1,3 @@
-import platform
 import sys
 
 __all__ = ['install', 'NullFinder']
@@ -52,5 +51,7 @@ def pypy_partial(val):
 
     Workaround for #327.
     """
+    import platform
+
     is_pypy = platform.python_implementation() == 'PyPy'
     return val + is_pypy

--- a/newsfragments/503.feature.rst
+++ b/newsfragments/503.feature.rst
@@ -1,0 +1,1 @@
+Deferred import of json


### PR DESCRIPTION
Staged on top of #502 

`platform` and `json` modules take together around 1.5ms to import, around 10% of total import time. Since they are both used in a single place it probably makes sense to inline their import.

After this PR, this is an output of `python -Ximporttime -c "import importlib_metadata"` visualized with tuna using cpython main branch.

![image](https://github.com/user-attachments/assets/6ad7a910-7e09-45ce-84bc-d9a9c7c094d6)
