### PR TITLE
Add Use Protocol from typing_extensions for Python < 3.8

### DIFF
--- a/importlib_metadata/_meta.py
+++ b/importlib_metadata/_meta.py
@@ -1,17 +1,21 @@
 from __future__ import annotations
 
 import os
+import sys
 from typing import (
     Any,
     Dict,
     Iterator,
     List,
     Optional,
-    Protocol,
     TypeVar,
     Union,
     overload,
 )
+if sys.version_info >= (3, 8):
+    from typing import Protocol
+else:
+    from typing_extensions import Protocol
 
 _T = TypeVar("_T")
 


### PR DESCRIPTION
No module 'typing_extensions' on Python 3.7 #352

This PR fixes an issue that causes an ImportError when importing importlib_metadata/_meta.py in Python 3.7. Since Protocol does not exist in typing in Python 3.7, this change ensures that it is imported from typing-extensions for Python versions earlier than 3.8.

