### PR TITLE
Raise consistent ValueError for invalid EntryPoint.value

### DIFF
--- a/importlib_metadata/__init__.py
+++ b/importlib_metadata/__init__.py
@@ -155,6 +155,22 @@ class EntryPoint:
     'attr'
     >>> ep.extras
     ['extra1', 'extra2']
+
+    If the value package or module are not valid identifiers, a
+    ValueError is raised on access.
+
+    >>> EntryPoint(name=None, group=None, value='invalid-name').module
+    Traceback (most recent call last):
+    ...
+    ValueError: ('Invalid object reference...invalid-name...
+    >>> EntryPoint(name=None, group=None, value='invalid-name').attr
+    Traceback (most recent call last):
+    ...
+    ValueError: ('Invalid object reference...invalid-name...
+    >>> EntryPoint(name=None, group=None, value='invalid-name').extras
+    Traceback (most recent call last):
+    ...
+    ValueError: ('Invalid object reference...invalid-name...
     """
 
     pattern = re.compile(
@@ -211,7 +227,13 @@ class EntryPoint:
     @property
     def _match(self) -> _EntryPointMatch:
         match = self.pattern.match(self.value)
-        assert match is not None
+        if not match:
+            raise ValueError(
+                'Invalid object reference. '
+                'See https://packaging.python.org'
+                '/en/latest/specifications/entry-points/#data-model',
+                self.value,
+            )
         return _EntryPointMatch(**match.groupdict())
 
     def _for(self, dist):

--- a/importlib_metadata/__init__.py
+++ b/importlib_metadata/__init__.py
@@ -171,6 +171,14 @@ class EntryPoint:
     Traceback (most recent call last):
     ...
     ValueError: ('Invalid object reference...invalid-name...
+
+    The same thing happens on construction.
+
+    >>> EntryPoint(name=None, group=None, value='invalid-name')
+    Traceback (most recent call last):
+    ...
+    ValueError: ('Invalid object reference...invalid-name...
+
     """
 
     pattern = re.compile(
@@ -202,6 +210,7 @@ class EntryPoint:
 
     def __init__(self, name: str, value: str, group: str) -> None:
         vars(self).update(name=name, value=value, group=group)
+        self.module
 
     def load(self) -> Any:
         """Load the entry point from its definition. If only a module

--- a/importlib_metadata/__init__.py
+++ b/importlib_metadata/__init__.py
@@ -233,7 +233,7 @@ class EntryPoint:
     def extras(self) -> list[str]:
         return re.findall(r'\w+', self._match.extras or '')
 
-    @property
+    @functools.cached_property
     def _match(self) -> _EntryPointMatch:
         match = self.pattern.match(self.value)
         if not match:


### PR DESCRIPTION
Closes #488

- **Refactored parsing and handling of EntryPoint.value.**
- **Raise a ValueError if no match.**
- **Also raise ValueError on construction if the value is invalid.**
- **Prefer a cached property, as the property is likely to be retrieved at least 3 times (on construction and for module:attr access).**
