### PR TITLE
Return None for missing metadata

### DIFF
--- a/importlib_metadata/__init__.py
+++ b/importlib_metadata/__init__.py
@@ -543,7 +543,7 @@ class Distribution(metaclass=abc.ABCMeta):
     @property
     def name(self) -> str:
         """Return the 'Name' metadata for the distribution package."""
-        return self.metadata['Name']
+        return cast(PackageMetadata, self.metadata)['Name']
 
     @property
     def _normalized_name(self):
@@ -553,7 +553,7 @@ class Distribution(metaclass=abc.ABCMeta):
     @property
     def version(self) -> str:
         """Return the 'Version' metadata for the distribution package."""
-        return self.metadata['Version']
+        return cast(PackageMetadata, self.metadata)['Version']
 
     @property
     def entry_points(self) -> EntryPoints:
@@ -1050,7 +1050,7 @@ def distributions(**kwargs) -> Iterable[Distribution]:
     return Distribution.discover(**kwargs)
 
 
-def metadata(distribution_name: str) -> _meta.PackageMetadata:
+def metadata(distribution_name: str) -> _meta.PackageMetadata | None:
     """Get the metadata for the named package.
 
     :param distribution_name: The name of the distribution package to query.
@@ -1125,7 +1125,7 @@ def packages_distributions() -> Mapping[str, list[str]]:
     pkg_to_dist = collections.defaultdict(list)
     for dist in distributions():
         for pkg in _top_level_declared(dist) or _top_level_inferred(dist):
-            pkg_to_dist[pkg].append(dist.metadata['Name'])
+            pkg_to_dist[pkg].append(cast(PackageMetadata, dist.metadata)['Name'])
     return dict(pkg_to_dist)
 
 

--- a/importlib_metadata/__init__.py
+++ b/importlib_metadata/__init__.py
@@ -27,7 +27,7 @@ from contextlib import suppress
 from importlib import import_module
 from importlib.abc import MetaPathFinder
 from itertools import starmap
-from typing import Any, cast
+from typing import Any
 
 from . import _meta
 from ._collections import FreezableDefaultDict, Pair
@@ -38,6 +38,7 @@ from ._compat import (
 from ._functools import method_cache, pass_none
 from ._itertools import always_iterable, bucket, unique_everseen
 from ._meta import PackageMetadata, SimplePath
+from ._typing import md_none
 from .compat import py39, py311
 
 __all__ = [
@@ -543,7 +544,7 @@ class Distribution(metaclass=abc.ABCMeta):
     @property
     def name(self) -> str:
         """Return the 'Name' metadata for the distribution package."""
-        return cast(PackageMetadata, self.metadata)['Name']
+        return md_none(self.metadata)['Name']
 
     @property
     def _normalized_name(self):
@@ -553,7 +554,7 @@ class Distribution(metaclass=abc.ABCMeta):
     @property
     def version(self) -> str:
         """Return the 'Version' metadata for the distribution package."""
-        return cast(PackageMetadata, self.metadata)['Version']
+        return md_none(self.metadata)['Version']
 
     @property
     def entry_points(self) -> EntryPoints:
@@ -1125,7 +1126,7 @@ def packages_distributions() -> Mapping[str, list[str]]:
     pkg_to_dist = collections.defaultdict(list)
     for dist in distributions():
         for pkg in _top_level_declared(dist) or _top_level_inferred(dist):
-            pkg_to_dist[pkg].append(cast(PackageMetadata, dist.metadata)['Name'])
+            pkg_to_dist[pkg].append(md_none(dist.metadata)['Name'])
     return dict(pkg_to_dist)
 
 

--- a/importlib_metadata/_typing.py
+++ b/importlib_metadata/_typing.py
@@ -1,0 +1,15 @@
+import functools
+import typing
+
+from ._meta import PackageMetadata
+
+md_none = functools.partial(typing.cast, PackageMetadata)
+"""
+Suppress type errors for optional metadata.
+
+Although Distribution.metadata can return None when metadata is corrupt
+and thus None, allow callers to assume it's not None and crash if
+that's the case.
+
+# python/importlib_metadata#493
+"""

--- a/importlib_metadata/compat/py39.py
+++ b/importlib_metadata/compat/py39.py
@@ -4,7 +4,7 @@ Compatibility layer with Python 3.8/3.9
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:  # pragma: no cover
     # Prevent circular imports on runtime.
@@ -12,7 +12,7 @@ if TYPE_CHECKING:  # pragma: no cover
 else:
     Distribution = EntryPoint = Any
 
-from .._meta import PackageMetadata
+from .._typing import md_none
 
 
 def normalized_name(dist: Distribution) -> str | None:
@@ -25,7 +25,7 @@ def normalized_name(dist: Distribution) -> str | None:
         from .. import Prepared  # -> delay to prevent circular imports.
 
         return Prepared.normalize(
-            getattr(dist, "name", None) or cast(PackageMetadata, dist.metadata)['Name']
+            getattr(dist, "name", None) or md_none(dist.metadata)['Name']
         )
 
 

--- a/importlib_metadata/compat/py39.py
+++ b/importlib_metadata/compat/py39.py
@@ -4,13 +4,15 @@ Compatibility layer with Python 3.8/3.9
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 if TYPE_CHECKING:  # pragma: no cover
     # Prevent circular imports on runtime.
     from .. import Distribution, EntryPoint
 else:
     Distribution = EntryPoint = Any
+
+from .._meta import PackageMetadata
 
 
 def normalized_name(dist: Distribution) -> str | None:
@@ -22,7 +24,9 @@ def normalized_name(dist: Distribution) -> str | None:
     except AttributeError:
         from .. import Prepared  # -> delay to prevent circular imports.
 
-        return Prepared.normalize(getattr(dist, "name", None) or dist.metadata['Name'])
+        return Prepared.normalize(
+            getattr(dist, "name", None) or cast(PackageMetadata, dist.metadata)['Name']
+        )
 
 
 def ep_matches(ep: EntryPoint, **params) -> bool:

--- a/newsfragments/493.feature.rst
+++ b/newsfragments/493.feature.rst
@@ -1,0 +1,1 @@
+``.metadata()`` (and ``Distribution.metadata``) can now return ``None`` if the metadata directory exists but not metadata file is present.

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -155,6 +155,16 @@ class InvalidMetadataTests(fixtures.OnSysPath, fixtures.SiteDir, unittest.TestCa
         dist = Distribution.from_name('foo')
         assert dist.version == "1.0"
 
+    def test_missing_metadata(self):
+        """
+        Dists with a missing metadata file should return None.
+
+        Ref python/importlib_metadata#493.
+        """
+        fixtures.build_files(self.make_pkg('foo-4.3', files={}), self.site_dir)
+        assert Distribution.from_name('foo').metadata is None
+        assert metadata('foo') is None
+
 
 class NonASCIITests(fixtures.OnSysPath, fixtures.SiteDir, unittest.TestCase):
     @staticmethod


### PR DESCRIPTION
Closes #493

- **Allow metadata to return None when there is no metadata present.**
- **Fix type errors where metadata could be None.**
- **Add news fragment.**
