### PR TITLE
Use `str.translate` to improve performance of `normalize`

### DIFF
--- a/importlib_metadata/__init__.py
+++ b/importlib_metadata/__init__.py
@@ -910,14 +910,6 @@ class Lookup:
         return itertools.chain(infos, eggs)
 
 
-# Translation table for Prepared.normalize: lowercase and
-# replace "-" (hyphen) and "." (dot) with "_" (underscore).
-_normalize_table = str.maketrans(
-    "ABCDEFGHIJKLMNOPQRSTUVWXYZ-.",
-    "abcdefghijklmnopqrstuvwxyz__",
-)
-
-
 class Prepared:
     """
     A prepared search query for metadata on a possibly-named package.
@@ -953,9 +945,8 @@ class Prepared:
         """
         PEP 503 normalization plus dashes as underscores.
         """
-        # Emulates ``re.sub(r"[-_.]+", "-", name).lower()`` from PEP 503
-        # About 3x faster, safe since packages only support alphanumeric characters
-        value = name.translate(_normalize_table)
+        # Much faster than re.sub, and even faster than str.translate
+        value = name.lower().replace("-", "_").replace(".", "_")
         # Condense repeats (faster than regex)
         while "__" in value:
             value = value.replace("__", "_")

--- a/importlib_metadata/__init__.py
+++ b/importlib_metadata/__init__.py
@@ -910,6 +910,14 @@ class Lookup:
         return itertools.chain(infos, eggs)
 
 
+# Translation table for Prepared.normalize: lowercase and
+# replace "-" (hyphen) and "." (dot) with "_" (underscore).
+_normalize_table = str.maketrans(
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZ-.",
+    "abcdefghijklmnopqrstuvwxyz__",
+)
+
+
 class Prepared:
     """
     A prepared search query for metadata on a possibly-named package.
@@ -945,7 +953,13 @@ class Prepared:
         """
         PEP 503 normalization plus dashes as underscores.
         """
-        return re.sub(r"[-_.]+", "-", name).lower().replace('-', '_')
+        # Emulates ``re.sub(r"[-_.]+", "-", name).lower()`` from PEP 503
+        # About 3x faster, safe since packages only support alphanumeric characters
+        value = name.translate(_normalize_table)
+        # Condense repeats (faster than regex)
+        while "__" in value:
+            value = value.replace("__", "_")
+        return value
 
     @staticmethod
     def legacy_normalize(name):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -6,6 +6,7 @@ import unittest
 from importlib_metadata import (
     Distribution,
     PackageNotFoundError,
+    Prepared,
     distribution,
     entry_points,
     files,
@@ -317,3 +318,36 @@ class InvalidateCache(unittest.TestCase):
     def test_invalidate_cache(self):
         # No externally observable behavior, but ensures test coverage...
         importlib.invalidate_caches()
+
+
+class PreparedTests(unittest.TestCase):
+    def test_normalize(self):
+        tests = [
+            # Simple
+            ("sample", "sample"),
+            # Mixed case
+            ("Sample", "sample"),
+            ("SAMPLE", "sample"),
+            ("SaMpLe", "sample"),
+            # Separator conversions
+            ("sample-pkg", "sample_pkg"),
+            ("sample.pkg", "sample_pkg"),
+            ("sample_pkg", "sample_pkg"),
+            # Multiple separators
+            ("sample---pkg", "sample_pkg"),
+            ("sample___pkg", "sample_pkg"),
+            ("sample...pkg", "sample_pkg"),
+            # Mixed separators
+            ("sample-._pkg", "sample_pkg"),
+            ("sample_.-pkg", "sample_pkg"),
+            # Complex
+            ("Sample__Pkg-name.foo", "sample_pkg_name_foo"),
+            ("Sample__Pkg.name__foo", "sample_pkg_name_foo"),
+            # Uppercase with separators
+            ("SAMPLE-PKG", "sample_pkg"),
+            ("Sample.Pkg", "sample_pkg"),
+            ("SAMPLE_PKG", "sample_pkg"),
+        ]
+        for name, expected in tests:
+            with self.subTest(name=name):
+                self.assertEqual(Prepared.normalize(name), expected)


### PR DESCRIPTION
This is the same as https://github.com/python/cpython/pull/143660.

---

We can apply @henryiii's improvement to `packaging` in https://github.com/pypa/packaging/pull/1030 (see also https://iscinumpy.dev/post/packaging-faster/) to improve the performance of `normalize` and make it ~3.7 times faster.

## Benchmark

Run `Prepared.normalize(n)` on every name in PyPI:

```python
# benchmark_names.py
import sqlite3
import timeit
from importlib_metadata import Prepared

# Get data with:
# curl -L https://github.com/pypi-data/pypi-json-data/releases/download/latest/pypi-data.sqlite.gz | gzip -d > pypi-data.sqlite
# Or ues pre-cached files from:
# https://gist.github.com/hugovk/efdbee0620cc64df7b405b52cf0b6e42

CACHE_FILE = "/tmp/bench/names.txt"
DB_FILE = "/tmp/bench/pypi-data.sqlite"

try:
    with open(CACHE_FILE) as f:
        TEST_ALL_NAMES = [line.rstrip("\n") for line in f]
except FileNotFoundError:
    TEST_ALL_NAMES = []
    with sqlite3.connect(DB_FILE) as conn:
        with open(CACHE_FILE, "w") as cache:
            for (name,) in conn.execute("SELECT name FROM projects"):
                if name:
                    TEST_ALL_NAMES.append(name)
                    cache.write(name + "\n")


def bench():
    for n in TEST_ALL_NAMES:
        Prepared.normalize(n)


if __name__ == "__main__":
    print(f"Loaded {len(TEST_ALL_NAMES):,} names")
    t = timeit.timeit("bench()", globals=globals(), number=1)
    print(f"Time: {t:.4f} seconds")
```

Benchmark data can be found at https://gist.github.com/hugovk/efdbee0620cc64df7b405b52cf0b6e42


## Before

```console
❯ python3.14 --version
Python 3.14.2

❯ python3.14 benchmark_names.py
Loaded 8,344,947 names
Time: 4.8933 seconds
```

## After

```console
❯ python3.14 benchmark_names.py
Loaded 8,344,947 names
Time: 1.3266 seconds
```

3.7 times faster.
