### PR TITLE
Prefer valid distributions when collecting entry points

### DIFF
--- a/importlib_metadata/__init__.py
+++ b/importlib_metadata/__init__.py
@@ -1121,6 +1121,21 @@ Wrapper for ``distributions`` to return unique distributions by name.
 """
 
 
+def _unique_valid(dists: Iterable[Distribution]) -> Iterable[Distribution]:
+    """
+    Return unique distributions, preferring valid metadata for duplicates.
+    """
+    has_metadata = ExceptionTrap(MetadataNotFound).passes(operator.attrgetter('metadata'))
+    unique: dict[str, Distribution] = {}
+    for dist in dists:
+        name = dist._normalized_name
+        if name not in unique:
+            unique[name] = dist
+        elif not has_metadata(unique[name]) and has_metadata(dist):
+            unique[name] = dist
+    return unique.values()
+
+
 def entry_points(**params) -> EntryPoints:
     """Return EntryPoint objects for all installed packages.
 
@@ -1131,7 +1146,7 @@ def entry_points(**params) -> EntryPoints:
     :return: EntryPoints for all installed packages.
     """
     eps = itertools.chain.from_iterable(
-        dist.entry_points for dist in _unique(distributions())
+        dist.entry_points for dist in _unique_valid(distributions())
     )
     return EntryPoints(eps).select(**params)
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -2,6 +2,7 @@ import importlib
 import pickle
 import re
 import unittest
+from unittest import mock
 
 import pyfakefs.fake_filesystem_unittest as ffs
 from test.support import os_helper
@@ -167,6 +168,38 @@ class InvalidMetadataTests(fixtures.OnSysPath, fixtures.SiteDir, unittest.TestCa
             Distribution.from_name('foo').metadata
         with self.assertRaises(MetadataNotFound):
             metadata('foo')
+
+    def test_entry_points_prefer_valid_distribution(self):
+        """
+        Entry points should be exposed from the valid distribution when an
+        empty dist-info directory for the same name is discovered first.
+
+        Ref python/importlib_metadata#534.
+        """
+        fixtures.build_files(self.make_pkg('foo-0.9', files={}), self.site_dir)
+        fixtures.build_files(
+            self.make_pkg(
+                'foo-1.0',
+                files={
+                    "METADATA": """
+                    Name: foo
+                    Version: 1.0
+                    """,
+                    "entry_points.txt": """
+                    [entries]
+                    main = mod:main
+                    """,
+                },
+            ),
+            self.site_dir,
+        )
+        dists = [
+            Distribution.at(self.site_dir / 'foo-0.9.dist-info'),
+            Distribution.at(self.site_dir / 'foo-1.0.dist-info'),
+        ]
+        with mock.patch.object(importlib_metadata, 'distributions', return_value=dists):
+            entries = importlib_metadata.entry_points(group='entries')
+        assert entries['main'].value == 'mod:main'
 
 
 class NonASCIITests(fixtures.OnSysPath, fixtures.SiteDir, unittest.TestCase):


### PR DESCRIPTION
Fixes #534

## Summary
- add a duplicate-aware distribution selector for `entry_points()` that replaces an invalid/empty dist-info entry with a later valid distribution of the same normalized name
- keep normal discovery order for unique distributions, avoiding the broader cost of preferring valid metadata for every distribution
- add a regression test where an empty older `foo.dist-info` appears before a valid one with entry points

## Tests
- Red before the fix: `PYTHONPATH=. uv run --python 3.11 --with '.[test]' pytest tests/test_main.py::InvalidMetadataTests::test_entry_points_prefer_valid_distribution -q` failed with `KeyError: 'main'`\n- `PYTHONPATH=. uv run --python 3.11 --with '.[test]' pytest tests/test_main.py::InvalidMetadataTests::test_entry_points_prefer_valid_distribution -q`\n- `PYTHONPATH=. uv run --python 3.11 --with '.[test]' pytest tests/test_main.py::InvalidMetadataTests tests/test_api.py::APITests::test_entry_points tests/test_api.py::APITests::test_entry_points_unique_packages_normalized -q`\n- `PYTHONPATH=. uv run --python 3.11 --with '.[test]' pytest -q`\n- `PYTHONPATH=. uv run --python 3.11 --with '.[test,check]' pytest --ruff -q`\n- `PYTHONPATH=. uv run --python 3.11 --with '.[test,type]' pytest --mypy -q`\n- `git diff --check`\n\nAI assistance was used under my direction.