### PR TITLE
Fix absolute RECORD path resolution

### DIFF
--- a/importlib_metadata/__init__.py
+++ b/importlib_metadata/__init__.py
@@ -1043,7 +1043,7 @@ class PathDistribution(Distribution):
     read_text.__doc__ = Distribution.read_text.__doc__
 
     def locate_file(self, path: str | os.PathLike[str]) -> SimplePath:
-        return self._path.parent / path
+        return self._path.parent / os.fspath(path)
 
     @property
     def _normalized_name(self):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,4 +1,5 @@
 import importlib
+import pathlib
 import re
 import textwrap
 import unittest
@@ -6,6 +7,8 @@ import unittest
 from importlib_metadata import (
     Distribution,
     PackageNotFoundError,
+    PackagePath,
+    PathDistribution,
     Prepared,
     distribution,
     entry_points,
@@ -191,6 +194,14 @@ class APITests(
 
     def test_files_dist_info(self):
         self._test_files(files('distinfo-pkg'))
+
+    def test_locate_file_with_windows_absolute_path(self):
+        dist = PathDistribution(pathlib.PureWindowsPath('C:/site/sample-1.0.dist-info'))
+        path = PackagePath('C:/venv/Scripts/sample.exe')
+
+        assert dist.locate_file(path) == pathlib.PureWindowsPath(
+            'C:/venv/Scripts/sample.exe'
+        )
 
     def test_files_egg_info(self):
         self._test_files(files('egginfo-pkg'))


### PR DESCRIPTION
Closes #535.

## Summary
- resolve `PathDistribution.locate_file()` paths through `os.fspath()` before joining with the distribution parent
- add a regression test that uses `PureWindowsPath` to cover absolute Windows RECORD entries on non-Windows hosts

## Verification
- `PYTHONPATH=. uv run --python 3.11 --with '.[test]' pytest tests/test_api.py::APITests::test_locate_file_with_windows_absolute_path -q`\n- `PYTHONPATH=. uv run --python 3.11 --with '.[test]' pytest tests/test_api.py::APITests::test_files_dist_info tests/test_api.py::APITests::test_files_egg_info -q`\n- `PYTHONPATH=. uv run --python 3.11 --with '.[test]' pytest -q`\n- `PYTHONPATH=. uv run --python 3.11 --with '.[test,check]' pytest --ruff -q`\n- `PYTHONPATH=. uv run --python 3.11 --with '.[test,type]' pytest --mypy -q`\n- `git diff --check`\n\nAI assistance was used under my direction.