### PR TITLE
Add Distribution.editable and top-level editable()

### DIFF
--- a/importlib_metadata/__init__.py
+++ b/importlib_metadata/__init__.py
@@ -51,6 +51,7 @@ __all__ = [
     'SimplePath',
     'distribution',
     'distributions',
+    'editable',
     'entry_points',
     'files',
     'metadata',
@@ -733,6 +734,18 @@ class Distribution(metaclass=abc.ABCMeta):
     def origin(self):
         return self._load_json('direct_url.json')
 
+    @property
+    def editable(self) -> bool:
+        """
+        Whether the distribution is an editable install (:pep:`660`).
+
+        Reads ``dir_info.editable`` from the :pep:`610` ``direct_url.json``,
+        defaulting to ``False`` when there is no origin or the package was
+        not installed from a local directory.
+        """
+        dir_info = getattr(self.origin, 'dir_info', None)
+        return bool(getattr(dir_info, 'editable', False))
+
     def _load_json(self, filename):
         # Deferred for performance (python/importlib_metadata#503)
         import json
@@ -1110,6 +1123,15 @@ def version(distribution_name: str) -> str:
         "Version" metadata key.
     """
     return distribution(distribution_name).version
+
+
+def editable(distribution_name: str) -> bool:
+    """Return whether the named distribution is an editable install.
+
+    :param distribution_name: The name of the distribution package to query.
+    :return: True if the package is installed in editable mode (:pep:`660`).
+    """
+    return distribution(distribution_name).editable
 
 
 _unique = functools.partial(

--- a/newsfragments/510.feature.rst
+++ b/newsfragments/510.feature.rst
@@ -1,0 +1,1 @@
+Added ``Distribution.editable`` property and top-level ``editable()`` function reporting whether a distribution is an editable install (:pep:`660`).

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -126,6 +126,21 @@ class DistInfoPkgEditable(DistInfoPkg):
     }
 
 
+class DistInfoPkgEditableDirInfo(DistInfoPkg):
+    """
+    Package installed as editable from a local directory (:pep:`660`).
+    """
+
+    files: FilesSpec = {
+        'distinfo_pkg-1.0.0.dist-info': {
+            'direct_url.json': json.dumps({
+                "dir_info": {"editable": True},
+                "url": "file:///path/to/distinfo_pkg",
+            })
+        },
+    }
+
+
 class DistInfoPkgWithDot(OnSysPath, SiteBuilder):
     files: FilesSpec = {
         "pkg_dot-1.0.0.dist-info": {

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -489,3 +489,23 @@ class EditableDistributionTest(fixtures.DistInfoPkgEditable, unittest.TestCase):
         dist = Distribution.from_name('distinfo-pkg')
         assert dist.origin.url.endswith('.whl')
         assert dist.origin.archive_info.hashes.sha256
+
+    def test_not_editable_from_archive(self):
+        # An origin without dir_info (here an archive) is not editable.
+        assert Distribution.from_name('distinfo-pkg').editable is False
+        assert importlib_metadata.editable('distinfo-pkg') is False
+
+
+class EditableDirInfoDistributionTest(
+    fixtures.DistInfoPkgEditableDirInfo, unittest.TestCase
+):
+    def test_editable(self):
+        assert Distribution.from_name('distinfo-pkg').editable is True
+        assert importlib_metadata.editable('distinfo-pkg') is True
+
+
+class NonEditableDistributionTest(fixtures.DistInfoPkg, unittest.TestCase):
+    def test_not_editable_without_origin(self):
+        # No direct_url.json means no origin, so not editable.
+        assert Distribution.from_name('distinfo-pkg').editable is False
+        assert importlib_metadata.editable('distinfo-pkg') is False


### PR DESCRIPTION
Closes #510

Adds `Distribution.editable` plus a top-level `editable()`, basically what you sketched in the issue. the property does the null-safe origin.dir_info.editable walk (defaults to False per PEP 610), and editable() just returns distribution(name).editable, same as version()/metadata().

tests cover editable via dir_info, not-editable (origin's there but it's archive_info, no dir_info), and no origin at all. heads up: the existing DistInfoPkgEditable fixture is actually an archive install despite the name, so i added a real dir_info one for the positive case. newsfragment in, full suite + mypy + ruff green.

happy to rename or drop either half if you'd rather go one way.
