### PR TITLE
Revert normalize() performance changes (gh-143658)

### DIFF
--- a/importlib_metadata/__init__.py
+++ b/importlib_metadata/__init__.py
@@ -962,15 +962,8 @@ class Prepared:
     def normalize(name):
         """
         PEP 503 normalization plus dashes as underscores.
-
-        Specifically avoids ``re.sub`` as prescribed for performance
-        benefits (see python/cpython#143658).
         """
-        value = name.lower().replace("-", "_").replace(".", "_")
-        # Condense repeats
-        while "__" in value:
-            value = value.replace("__", "_")
-        return value
+        return re.sub(r"[-_.]+", "-", name).lower().replace('-', '_')
 
     @staticmethod
     def legacy_normalize(name):


### PR DESCRIPTION
Reverts the `importlib_metadata/__init__.py` `Prepared.normalize()` changes introduced by the merge 8c5d91b58a — the `str.translate`/`str.replace` optimizations from python/cpython#143660 (3e7f3ac) and python/cpython#144083 (001db0db09), along with 27169dcd34's docstring note — restoring the original `re.sub`-based implementation:

```python
def normalize(name):
    """
    PEP 503 normalization plus dashes as underscores.
    """
    return re.sub(r"[-_.]+", "-", name).lower().replace('-', '_')
```

Only `__init__.py` is touched; the behavioral tests added alongside those commits remain and pass against this implementation.

Closes #540

🤖 Generated with [Claude Code](https://claude.com/claude-code)