### PR TITLE
Make SimplePath path parameters positional-only

### DIFF
--- a/importlib_metadata/_meta.py
+++ b/importlib_metadata/_meta.py
@@ -54,11 +54,11 @@ class SimplePath(Protocol):
     """
 
     def joinpath(
-        self, other: str | os.PathLike[str]
+        self, other: str | os.PathLike[str], /
     ) -> SimplePath: ...  # pragma: no cover
 
     def __truediv__(
-        self, other: str | os.PathLike[str]
+        self, other: str | os.PathLike[str], /
     ) -> SimplePath: ...  # pragma: no cover
 
     @property

--- a/newsfragments/542.bugfix.rst
+++ b/newsfragments/542.bugfix.rst
@@ -1,0 +1,1 @@
+Marked the ``other`` parameter of ``SimplePath.joinpath`` and ``SimplePath.__truediv__`` positional-only, so ``pathlib.Path`` satisfies the protocol under type checkers that compare parameter names.


### PR DESCRIPTION
Fixes #542.

`SimplePath` names the `joinpath` and `__truediv__` parameter `other` without marking it positional-only, so the typing spec requires an implementation to accept `other=...`. Typeshed names the matching `pathlib.Path` parameters `key` and `*other`, so `Path` fails the protocol under checkers that compare parameter names:

```python
import pathlib

from importlib_metadata import PathDistribution

PathDistribution(pathlib.Path('x'))
```

ty 0.0.59 explains it:

```
info: type `Path` is not assignable to protocol `SimplePath`
info: └── protocol member `__truediv__` is incompatible
info:     └── the parameter named `key` does not match `other` (and can be used as a keyword parameter)
```

pyrefly 1.1.1 reports the same. mypy 2.1.0 accepts it, which is why the docstring's claim that `SimplePath` is "A minimal subset of pathlib.Path" has held up until now.

Adding `/` to both members lets `Path` satisfy the protocol under ty and pyrefly, and leaves mypy passing. I verified all three against importlib_metadata 9.0.0 with the parameters patched, and checked each protocol member against `Path` in isolation: `joinpath` and `__truediv__` were the only failures.

`ruff format`, `ruff check` and `mypy` pass. `tox -e py` fails to collect on this branch, but it fails the same way on a pristine `main` checkout, so that is unrelated.

pypa/build ran into this while moving off mypy (pypa/build#1135).
